### PR TITLE
HA00, Халанский

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,3 +3,12 @@ name := "scala-2018"
 version := "0.1"
 
 scalaVersion := "2.12.7"
+
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots")
+)
+
+libraryDependencies ++= Seq(
+  "com.chuusai" %% "shapeless" % "2.3.3"
+)

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler142.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler142.scala
@@ -74,17 +74,18 @@ object Euler142 {
   def ans(n: Int): Int = {
     for (a <- 1 to n) {
       val a1 = a * a
-      for (pc <- 0 to (a/2)) {
-        val c = 2*pc + (a%2)
+      for (pc <- 0 to (a / 2)) {
+        val c = 2 * pc + (a % 2)
         if (c != 0) {
           val c1 = c * c
-          if (isSquare(a1-c1)) {
-            for (pb <- 0 to (c/2)) {
-              val b = 2*pb + (a%2)
+          if (isSquare(a1 - c1)) {
+            for (pb <- 0 to (c / 2)) {
+              val b = 2 * pb + (a % 2)
               if (b != 0) {
                 val b1 = b * b
-                if (isSquare(c1-b1) && isSquare(a1+b1-c1) && a1+b1 < 2 * c1) {
-                  return c1 + (a1-b1)/2
+                if (isSquare(c1 - b1) && isSquare(a1 + b1 - c1) && a1 + b1 < 2 * c1) {
+                  println(a1, " ", b1, " ", c1)
+                  return c1 + (a1 - b1) / 2
                 }
               }
             }
@@ -100,19 +101,46 @@ object Euler142I {
 
   import TypeLevelI._
   import Bin._
+  import Bool._
   import Maybe._
   import Ops._
 
-  type Condition[A1 <: Bin, B1 <: Bin, C1 <: Bin] = A1#add[B1]#suc#le[O[C1]#norm]#and[isSquare[C1#sub[B1]]#and[isSquare[A1#add[B1]#sub[C1]]]]
-  type Returns[A1 <: Bin, B1 <: Bin, C1 <: Bin] = Condition[A1, B1, C1]#select[Maybe[Bin], Just[Bin, C1#add[A1#sub[B1]#halve]], Nothing[Bin]]
-  type BBody[A1 <: Bin, C1 <: Bin, B <: Bin] = B#isZero#select[Maybe[Bin], Nothing[Bin], Returns[A1, B#mul[B], C1]]
-  type BBodyBDef[A1 <: Bin, C <: Bin, C1 <: Bin, PB <: Bin] = BBody[A1, C1, O[PB]#norm#add[C#mod2]]
-  type BLoop[A1 <: Bin, C <: Bin, C1 <: Bin] = find[Bin, ({type Z[PB <: Bin] = BBodyBDef[A1, C, C1, PB] })#Z, C#halve]
-  type CBodyReturns[A1 <: Bin, C <: Bin, C1 <: Bin] = isSquare[A1#sub[C1]]#select[Maybe[Bin], BLoop[A1, C, C1], Nothing[Bin]]
-  type CBody[A1 <: Bin, C <: Bin] = C#isZero#select[Maybe[Bin], Nothing[Bin], CBodyReturns[A1, C, C#mul[C]]]
-  type CBodyCDef[A <: Bin, A1 <: Bin, PC <: Bin] = CBody[A1, O[PC]#norm#add[A#mod2]]
-  type CLoop[A <: Bin, A1 <: Bin] = find[Bin, ({type Z[PC <: Bin] = CBodyCDef[A, A1, PC] })#Z, A#halve]
+  type Condition[A1 <: Bin, B1 <: Bin, C1 <: Bin] =
+    A1#add[B1]#suc#le[O[C1]#norm]#and[isSquare[C1#sub[B1]]#and[isSquare[
+      A1#add[B1]#sub[C1]]]]
+  type Returns[A1 <: Bin, B1 <: Bin, C1 <: Bin] =
+    Condition[A1, B1, C1]#select[Maybe[Bin],
+                                 Just[Bin, C1#add[A1#sub[B1]#halve]],
+                                 Nothing[Bin]]
+  type BBody[A1 <: Bin, C1 <: Bin, B <: Bin] =
+    B#isZero#select[Maybe[Bin], Nothing[Bin], Returns[A1, B#mul[B], C1]]
+  type BBodyBDef[A1 <: Bin, C <: Bin, C1 <: Bin, PB <: Bin] =
+    BBody[A1, C1, O[PB]#norm#add[C#mod2]]
+  type BLoop[A1 <: Bin, C <: Bin, C1 <: Bin] =
+    find[Bin, ({ type Z[PB <: Bin] = BBodyBDef[A1, C, C1, PB] })#Z, C#halve]
+  type CBodyReturns[A1 <: Bin, C <: Bin, C1 <: Bin] =
+    isSquare[A1#sub[C1]]#select[Maybe[Bin], BLoop[A1, C, C1], Nothing[Bin]]
+  type CBody[A1 <: Bin, C <: Bin] =
+    C#isZero#select[Maybe[Bin], Nothing[Bin], CBodyReturns[A1, C, C#mul[C]]]
+  type CBodyCDef[A <: Bin, A1 <: Bin, PC <: Bin] =
+    CBody[A1, O[PC]#norm#add[A#mod2]]
+  type CLoop[A <: Bin, A1 <: Bin] =
+    find[Bin, ({ type Z[PC <: Bin] = CBodyCDef[A, A1, PC] })#Z, A#halve]
   type ABody[A <: Bin] = CLoop[A, A#mul[A]]
   type Ans[N <: Bin] = find[Bin, ABody, N]
+
+  // a1
+  type _855625 =
+    _8#mul[_10]#add[_5]#mul[_10]#add[_5]#mul[_10]#add[_6]#mul[_10]#add[_2]#mul[
+      _10]#add[_5]
+  // b1
+  type _13689 =
+    _1#mul[_10]#add[_3]#mul[_10]#add[_6]#mul[_10]#add[_8]#mul[_10]#add[_9]
+  // c1
+  type _585225 =
+    _5#mul[_10]#add[_8]#mul[_10]#add[_5]#mul[_10]#add[_2]#mul[_10]#add[_2]#mul[
+      _10]#add[_5]
+
+  // implicitly[isSquare[_585225#sub[_13689]] =:= T] // already takes a long time
 
 }

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler142.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler142.scala
@@ -1,0 +1,118 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+
+/*
+The task is to find such x, y, z that
+  x + y = c
+  x - y = d
+  x + z = e
+  x - z = f
+  y + z = g
+  y - z = h
+where c, d, e, f, g, h are perfect squares.
+
+By adding and subtracting the first equation to and from everything else, we
+get
+
+  x = (c + d) / 2
+  y = (c - d) / 2
+  h = c - e
+  g = c - f
+
+Then, by adding and subtracting the third equation to and from some of the
+others, we also get
+
+  g = e - d
+  h = f - d
+  z = (e - f) / 2
+
+From this, we can derive that `x + y + z` is `c + (e - f) / 2`, which tells us
+that the difference between `e` and `f` must be an even number. We also derive
+that
+
+  c - e = f - d = h
+  c - f = e - d = g
+
+From here, we arrive to the following form:
+
+  c = e + h
+  c = f + g
+  d = f - h
+
+Remembering that c, e, f, and d are all perfect squares, we conclude that the
+solution can be derived by finding two right triangles with the same hypotenuse
+and different catets. It is also imperative that the difference between the
+squares of the larger catet of one triangle and the smaller catet of another
+triangle is a perfect square, and that the larger catets of the triangles have
+the same evenness.
+
+It turns out that these requirements are sufficient. By plugging these
+properties into the initial problem, we can verify that any solution of the
+described form will do.
+
+So, we need to:
+ * Iterate all the Pythagorean triples;
+ * Group the triples by the largest component;
+ * For each group, try to match every triple with every other triple and see
+    if the difference between their second components is even, and that the
+    difference between the second component of one of the triples and the third
+    component of the other is a perfect square. If so, we've found our answer.
+ */
+
+object Euler142 {
+
+  def isSquare(n: Long): Boolean = {
+    def helper(l: Long, h: Long): Boolean = {
+      val mid = l + (h - l) / 2
+      l <= h && (n == mid * mid || (if (n < mid * mid) helper(l, mid - 1)
+                                    else helper(mid + 1, h)))
+    }
+    helper(1, n)
+  }
+
+  /* If `x`, `y`, and `z` for the required answer lie in [1; n], output the
+     answer. */
+  def ans(n: Int): Int = {
+    for (a <- 1 to n) {
+      val a1 = a * a
+      for (pc <- 0 to (a/2)) {
+        val c = 2*pc + (a%2)
+        if (c != 0) {
+          val c1 = c * c
+          if (isSquare(a1-c1)) {
+            for (pb <- 0 to (c/2)) {
+              val b = 2*pb + (a%2)
+              if (b != 0) {
+                val b1 = b * b
+                if (isSquare(c1-b1) && isSquare(a1+b1-c1) && a1+b1 < 2 * c1) {
+                  return c1 + (a1-b1)/2
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    0
+  }
+}
+
+object Euler142I {
+
+  import TypeLevelI._
+  import Bin._
+  import Maybe._
+  import Ops._
+
+  type Condition[A1 <: Bin, B1 <: Bin, C1 <: Bin] = A1#add[B1]#suc#le[O[C1]#norm]#and[isSquare[C1#sub[B1]]#and[isSquare[A1#add[B1]#sub[C1]]]]
+  type Returns[A1 <: Bin, B1 <: Bin, C1 <: Bin] = Condition[A1, B1, C1]#select[Maybe[Bin], Just[Bin, C1#add[A1#sub[B1]#halve]], Nothing[Bin]]
+  type BBody[A1 <: Bin, C1 <: Bin, B <: Bin] = B#isZero#select[Maybe[Bin], Nothing[Bin], Returns[A1, B#mul[B], C1]]
+  type BBodyBDef[A1 <: Bin, C <: Bin, C1 <: Bin, PB <: Bin] = BBody[A1, C1, O[PB]#norm#add[C#mod2]]
+  type BLoop[A1 <: Bin, C <: Bin, C1 <: Bin] = find[Bin, ({type Z[PB <: Bin] = BBodyBDef[A1, C, C1, PB] })#Z, C#halve]
+  type CBodyReturns[A1 <: Bin, C <: Bin, C1 <: Bin] = isSquare[A1#sub[C1]]#select[Maybe[Bin], BLoop[A1, C, C1], Nothing[Bin]]
+  type CBody[A1 <: Bin, C <: Bin] = C#isZero#select[Maybe[Bin], Nothing[Bin], CBodyReturns[A1, C, C#mul[C]]]
+  type CBodyCDef[A <: Bin, A1 <: Bin, PC <: Bin] = CBody[A1, O[PC]#norm#add[A#mod2]]
+  type CLoop[A <: Bin, A1 <: Bin] = find[Bin, ({type Z[PC <: Bin] = CBodyCDef[A, A1, PC] })#Z, A#halve]
+  type ABody[A <: Bin] = CLoop[A, A#mul[A]]
+  type Ans[N <: Bin] = find[Bin, ABody, N]
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
@@ -23,19 +23,20 @@ package ru.hse.spb.jvm.scala.dkhalansky.euler
 
    All that's left now is to find the closed form of the sum among rows, which
    is done mechanically.
-*/
+ */
 
 object Euler148 {
 
-  def z(n: Long, p: Long, a: Long) = n * (n+1) * p / 2 + (n+1) * a
+  def z(n: Long, p: Long, a: Long) = n * (n + 1) * p / 2 + (n + 1) * a
 
-  def f(n: Long, p: Long, a: Long): Long = if (n < 7) {
-    z(n, p, a)
-  } else {
-    val q = n / 7
-    val r = n % 7
-    f(q, p * 28, z(r, p, a))
-  }
+  def f(n: Long, p: Long, a: Long): Long =
+    if (n < 7) {
+      z(n, p, a)
+    } else {
+      val q = n / 7
+      val r = n % 7
+      f(q, p * 28, z(r, p, a))
+    }
 
   def ans(n: Long): Long = f(n, 1, 0)
 }
@@ -46,35 +47,54 @@ object Euler148T {
 
   trait Z[N <: Bin, P <: Bin, A <: Bin] { type Out <: Bin }
   object Z {
-    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = Z[N, P, A] { type Out = R }
-    implicit def c[N <: Bin, P <: Bin, A <: Bin, N1 <: Bin, NmN1 <: Bin, FP <: Bin, FV <: Bin, M2 <: Bin, X <: Bin](
-      implicit n1: BinSuc.Aux[N, N1],
-      nmn1: BinMult.Aux[N, N1, NmN1],
-      fp: BinMult.Aux[NmN1, P, FP],
-      d2: BinDiv.Aux[FP, __2, FV, E],
-      m2: BinMult.Aux[N1, A, M2],
-      c: BinAdd[M2, FV]): Aux[N, P, A, c.Out] = ???
+    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = Z[N, P, A] {
+      type Out = R
+    }
+    implicit def c[N <: Bin,
+                   P <: Bin,
+                   A <: Bin,
+                   N1 <: Bin,
+                   NmN1 <: Bin,
+                   FP <: Bin,
+                   FV <: Bin,
+                   M2 <: Bin,
+                   X <: Bin](implicit n1: BinSuc.Aux[N, N1],
+                             nmn1: BinMult.Aux[N, N1, NmN1],
+                             fp: BinMult.Aux[NmN1, P, FP],
+                             d2: BinDiv.Aux[FP, __2, FV, E],
+                             m2: BinMult.Aux[N1, A, M2],
+                             c: BinAdd[M2, FV]): Aux[N, P, A, c.Out] = ???
   }
 
   implicitly[Z.Aux[__2, __2, __4, __18]]
 
   trait F[N <: Bin, P <: Bin, A <: Bin] { type Out <: Bin }
   object F {
-    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = F[N, P, A] { type Out = R }
-    implicit def cL[N <: Bin, P <: Bin, A <: Bin](implicit c: BinLt[N, __7], q: Z[N, P, A]): Aux[N, P, A, q.Out] = ???
-    implicit def cG[N <: Bin, P <: Bin, A <: Bin, Q <: Bin, R <: Bin, V <: Bin, P28 <: Bin](
-      implicit c: BinLe[__7, N],
-      dm: BinDiv.Aux[N, __7, Q, R],
-      p28: BinMult.Aux[P, __28, P28],
-      q: Z.Aux[R, P, A, V],
-      p: F[Q, P28, V]): Aux[N, P, A, p.Out] = ???
+    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = F[N, P, A] {
+      type Out = R
+    }
+    implicit def cL[N <: Bin, P <: Bin, A <: Bin](
+        implicit c: BinLt[N, __7],
+        q: Z[N, P, A]): Aux[N, P, A, q.Out] = ???
+    implicit def cG[N <: Bin,
+                    P <: Bin,
+                    A <: Bin,
+                    Q <: Bin,
+                    R <: Bin,
+                    V <: Bin,
+                    P28 <: Bin](implicit c: BinLe[__7, N],
+                                dm: BinDiv.Aux[N, __7, Q, R],
+                                p28: BinMult.Aux[P, __28, P28],
+                                q: Z.Aux[R, P, A, V],
+                                p: F[Q, P28, V]): Aux[N, P, A, p.Out] = ???
   }
 
   implicitly[F.Aux[__7, __28, __10, __804]]
 
   trait Ans[N <: Bin] { type Out <: Bin }
   object Ans {
-    implicit def c[N <: Bin](implicit c: F[N, __1, __0]): Ans[N] { type Out = c.Out } = ???
+    implicit def c[N <: Bin](
+        implicit c: F[N, __1, __0]): Ans[N] { type Out = c.Out } = ???
   }
 
   implicitly[Ans[__4] { type Out = __10 }]

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
@@ -85,10 +85,11 @@ object Euler148T {
                     V <: Bin,
                     P28 <: Bin,
                     Z <: Bin](implicit c: BinLe[__7, N],
-                                dm: BinDiv.Aux[N, __7, Q, R],
-                                p28: BinMult.Aux[P, __28, P28],
-                                q: Z.Aux[R, P, A, V],
-                                p: Lazy[Aux[Q, P28, V, Z]]): Aux[N, P, A, Z] = ???
+                              dm: BinDiv.Aux[N, __7, Q, R],
+                              p28: BinMult.Aux[P, __28, P28],
+                              q: Z.Aux[R, P, A, V],
+                              p: Lazy[Aux[Q, P28, V, Z]]): Aux[N, P, A, Z] =
+      ???
   }
 
   implicitly[F.Aux[__7, __28, __10, __804]]

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
@@ -1,4 +1,5 @@
 package ru.hse.spb.jvm.scala.dkhalansky.euler
+import shapeless.Lazy
 
 /* First, observe that a number `n!` is strictly divided by `7^k` where
 
@@ -82,11 +83,12 @@ object Euler148T {
                     Q <: Bin,
                     R <: Bin,
                     V <: Bin,
-                    P28 <: Bin](implicit c: BinLe[__7, N],
+                    P28 <: Bin,
+                    Z <: Bin](implicit c: BinLe[__7, N],
                                 dm: BinDiv.Aux[N, __7, Q, R],
                                 p28: BinMult.Aux[P, __28, P28],
                                 q: Z.Aux[R, P, A, V],
-                                p: F[Q, P28, V]): Aux[N, P, A, p.Out] = ???
+                                p: Lazy[Aux[Q, P28, V, Z]]): Aux[N, P, A, Z] = ???
   }
 
   implicitly[F.Aux[__7, __28, __10, __804]]
@@ -101,9 +103,9 @@ object Euler148T {
   implicitly[Ans[__5] { type Out = __15 }]
   implicitly[Ans[__10] { type Out = __40 }] // takes a long time
 
-  /* this computation is so long that the compiler thinks that we're in an
-     endless loop. If we perform the calculations separately, they give the
-     correct result. */
-  // implicitly[Ans[__53] { type Out = __804 }] // diverging implicit expansion
+  /* without a `Lazy`, this computation is so long that the compiler thinks
+     that we're in an endless loop. If we perform the calculations separately
+     or add the `Lazy` wrapper, they give the correct result. */
+  implicitly[Ans[__53] { type Out = __804 }] // diverging implicit expansion
 
 }

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler148.scala
@@ -1,0 +1,89 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+
+/* First, observe that a number `n!` is strictly divided by `7^k` where
+
+   k = floor(n/7) + floor(n/7^2) + floor(n/7^3) + ...
+
+   So, in order for C(n, k) not to divide 7, it must be true that
+
+   sum_i floor(n/7^i) = sum_i (floor(k/7^i) + floor((n-k)/7^i))
+
+   Since this function is monotonous in each component of the sum, this
+   requirement is equivalent to
+
+   forall i, floor(n/7^i) = floor(k/7^i) + floor((n-k)/7^i)
+
+   Observe that if `r = floor(n/7^i)`, then we have `r+1` ways to split
+   whole 7^i's among `n` and `n-k` in such a way that this condition is
+   fulfilled.
+
+   Now, this gives us an efficient way of finding the number of elements not
+   divisible by 7 in the n'th row: we only have to find the representation of
+   `n` base 7 and multiply its digits+1.
+
+   All that's left now is to find the closed form of the sum among rows, which
+   is done mechanically.
+*/
+
+object Euler148 {
+
+  def z(n: Long, p: Long, a: Long) = n * (n+1) * p / 2 + (n+1) * a
+
+  def f(n: Long, p: Long, a: Long): Long = if (n < 7) {
+    z(n, p, a)
+  } else {
+    val q = n / 7
+    val r = n % 7
+    f(q, p * 28, z(r, p, a))
+  }
+
+  def ans(n: Long): Long = f(n, 1, 0)
+}
+
+object Euler148T {
+
+  import TypeFramework.Bin._
+
+  trait Z[N <: Bin, P <: Bin, A <: Bin] { type Out <: Bin }
+  object Z {
+    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = Z[N, P, A] { type Out = R }
+    implicit def c[N <: Bin, P <: Bin, A <: Bin, N1 <: Bin, NmN1 <: Bin, FP <: Bin, FV <: Bin, M2 <: Bin, X <: Bin](
+      implicit n1: BinSuc.Aux[N, N1],
+      nmn1: BinMult.Aux[N, N1, NmN1],
+      fp: BinMult.Aux[NmN1, P, FP],
+      d2: BinDiv.Aux[FP, __2, FV, E],
+      m2: BinMult.Aux[N1, A, M2],
+      c: BinAdd[M2, FV]): Aux[N, P, A, c.Out] = ???
+  }
+
+  implicitly[Z.Aux[__2, __2, __4, __18]]
+
+  trait F[N <: Bin, P <: Bin, A <: Bin] { type Out <: Bin }
+  object F {
+    type Aux[N <: Bin, P <: Bin, A <: Bin, R <: Bin] = F[N, P, A] { type Out = R }
+    implicit def cL[N <: Bin, P <: Bin, A <: Bin](implicit c: BinLt[N, __7], q: Z[N, P, A]): Aux[N, P, A, q.Out] = ???
+    implicit def cG[N <: Bin, P <: Bin, A <: Bin, Q <: Bin, R <: Bin, V <: Bin, P28 <: Bin](
+      implicit c: BinLe[__7, N],
+      dm: BinDiv.Aux[N, __7, Q, R],
+      p28: BinMult.Aux[P, __28, P28],
+      q: Z.Aux[R, P, A, V],
+      p: F[Q, P28, V]): Aux[N, P, A, p.Out] = ???
+  }
+
+  implicitly[F.Aux[__7, __28, __10, __804]]
+
+  trait Ans[N <: Bin] { type Out <: Bin }
+  object Ans {
+    implicit def c[N <: Bin](implicit c: F[N, __1, __0]): Ans[N] { type Out = c.Out } = ???
+  }
+
+  implicitly[Ans[__4] { type Out = __10 }]
+  implicitly[Ans[__5] { type Out = __15 }]
+  implicitly[Ans[__10] { type Out = __40 }] // takes a long time
+
+  /* this computation is so long that the compiler thinks that we're in an
+     endless loop. If we perform the calculations separately, they give the
+     correct result. */
+  // implicitly[Ans[__53] { type Out = __804 }] // diverging implicit expansion
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
@@ -33,4 +33,54 @@ object Euler164 {
 
 }
 
-object Euler164I {}
+object Euler164I {
+
+  import TypeLevelI._
+  import Bin._
+  import Bin.Ops._
+  import TList._
+  import TList.Ops._
+  import Bool._
+  import Maybe._
+
+  type _0to9 = range[_9]
+
+  type _99 = _9#mul[_10#suc]
+
+  type _0to99 = range[_99]
+
+  type mask = concat[TList[Bool], _0to9#map[TList[TList[Bool]],
+      ({type Z[X <: Bin] = _0to9#map[TList[Bool],
+          ({type Z1[M <: Bin] = concat[Bool, _0to9#map[TList[Bool],
+              ({type Z2[R <: Bin] = _0to9#map[Bool,
+                  ({type Z3[Y <: Bin] =
+                      eq[M, R]#and[X#add[M]#add[Y]#le[_9]]})#Z3
+              ]})#Z2
+          ]]})#Z1]})#Z]]
+
+/*
+  // Stack overflow after 10 minutes
+  implicitly[mask#head =:= Just[TList[Bool],
+      replicate[Bool, _10, T]#append[replicate[Bool, _10#mul[_9], F]]]]
+*/
+
+  type step[O <: TList[Bin]] = mask#zip[Bin, O]#
+    map[TList[Bin],
+    ({type Z[X <: Pair[TList[Bool], Bin]] =
+        X#fst#map[Bin, ({type Z1[A <: Bool] = A#select[Bin, X#snd, _0] })#Z1]
+    })#Z]#
+    foldr[TList[Bin],
+        ({type Z[X <: TList[Bin], P <: TList[Bin]] =
+            X#zip[Bin, P]#map[Bin,
+                ({type Z1[A <: Pair[Bin, Bin]] = A#fst#add[A#snd]})#Z1]})#Z,
+        replicate[Bin, _99#suc, _0]]
+
+  type withZeros[N <: Bin] = sum[range[N#pred]#foldr[TList[Bin],
+    ({type Z[_ <: Bin, A <: TList[Bin]] = step[A]})#Z,
+    replicate[Bin, _99#suc, _1]]]
+
+  // implicitly[withZeros[_0] =:= _99#suc]
+
+  type ans[N <: Bin] = withZeros[N#pred]#sub[withZeros[N#pred#pred]]
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
@@ -1,0 +1,29 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+import scala.collection.immutable.IndexedSeq
+
+/* This is a simple task on dynamics with profile. First, we calculate
+   how rows are matched one to another. Then, keeping a list of current
+   matches, we update it iteratively.
+*/
+object Euler164 {
+
+  def mask(): IndexedSeq[IndexedSeq[Boolean]] = {
+    for (x <- 0 to 9; m <- 0 to 9)
+      yield for (r <- 0 to 9; y <- 0 to 9)
+        yield r == m && x + m + y <= 9
+  }
+
+  def step(old: IndexedSeq[Long], mask: IndexedSeq[IndexedSeq[Boolean]]): IndexedSeq[Long] = {
+    for (x <- 0 to 99) yield (0 to 99).filter(mask(x)(_)).foldLeft(0L)(_ + old(_))
+  }
+
+  def withZeros(n: Int, mask: IndexedSeq[IndexedSeq[Boolean]]): Long = {
+    (1 to n).foldLeft((0 to 99).map(_ => 1L))((ac, _) => step(ac, mask)).foldLeft(0L)(_ + _)
+  }
+
+  def ans(n: Int): Long = {
+    val m = mask()
+    withZeros(n-2, m) - withZeros(n-3, m)
+  }
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
@@ -4,26 +4,33 @@ import scala.collection.immutable.IndexedSeq
 /* This is a simple task on dynamics with profile. First, we calculate
    how rows are matched one to another. Then, keeping a list of current
    matches, we update it iteratively.
-*/
+ */
 object Euler164 {
 
   def mask(): IndexedSeq[IndexedSeq[Boolean]] = {
     for (x <- 0 to 9; m <- 0 to 9)
-      yield for (r <- 0 to 9; y <- 0 to 9)
-        yield r == m && x + m + y <= 9
+      yield
+        for (r <- 0 to 9; y <- 0 to 9)
+          yield r == m && x + m + y <= 9
   }
 
-  def step(old: IndexedSeq[Long], mask: IndexedSeq[IndexedSeq[Boolean]]): IndexedSeq[Long] = {
-    for (x <- 0 to 99) yield (0 to 99).filter(mask(x)(_)).foldLeft(0L)(_ + old(_))
+  def step(old: IndexedSeq[Long],
+           mask: IndexedSeq[IndexedSeq[Boolean]]): IndexedSeq[Long] = {
+    for (x <- 0 to 99)
+      yield (0 to 99).filter(mask(x)(_)).foldLeft(0L)(_ + old(_))
   }
 
   def withZeros(n: Int, mask: IndexedSeq[IndexedSeq[Boolean]]): Long = {
-    (1 to n).foldLeft((0 to 99).map(_ => 1L))((ac, _) => step(ac, mask)).foldLeft(0L)(_ + _)
+    (1 to n)
+      .foldLeft((0 to 99).map(_ => 1L))((ac, _) => step(ac, mask))
+      .foldLeft(0L)(_ + _)
   }
 
   def ans(n: Int): Long = {
     val m = mask()
-    withZeros(n-2, m) - withZeros(n-3, m)
+    withZeros(n - 2, m) - withZeros(n - 3, m)
   }
 
 }
+
+object Euler164I {}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler164.scala
@@ -75,11 +75,11 @@ object Euler164I {
                 ({type Z1[A <: Pair[Bin, Bin]] = A#fst#add[A#snd]})#Z1]})#Z,
         replicate[Bin, _99#suc, _0]]
 
-  type withZeros[N <: Bin] = sum[range[N#pred]#foldr[TList[Bin],
+  type withZeros[N <: Bin] = sum[replicate[Bin, N#pred, _0]#foldr[TList[Bin],
     ({type Z[_ <: Bin, A <: TList[Bin]] = step[A]})#Z,
     replicate[Bin, _99#suc, _1]]]
 
-  // implicitly[withZeros[_0] =:= _99#suc]
+  implicitly[withZeros[_0] =:= _99#suc]
 
   type ans[N <: Bin] = withZeros[N#pred]#sub[withZeros[N#pred#pred]]
 

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler504.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler504.scala
@@ -1,0 +1,143 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+import shapeless.Lazy
+
+/*
+This solution is straightforward. First, observe that we can split the solution
+space by splitting the figure by the axes. Second, we can count the number of
+elements in each triangle that are contained strictly using the formula
+  2 * (a * b - gcd(a, b)) + 1
+Next, we just iterate through all the boundaries to find the answer.
+Now, it could be sped up by memoization of results for triangles, but it's fast
+enough as it is in compiled code, and in the type level memoization doesn't
+work as well due to lack of random-access structures.
+ */
+
+object Euler504 {
+
+  def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+
+  def f(a: Int, b: Int): Int = 2 * (a * b - gcd(a, b)) + 1
+
+  def isSquare(n: Int): Boolean = {
+    def helper(l: Int, h: Int): Boolean = {
+      val mid = l + (h - l) / 2
+      l <= h && (n == mid * mid || (if (n < mid * mid) helper(l, mid - 1)
+                                    else helper(mid + 1, h)))
+    }
+    helper(1, n)
+  }
+
+  def ans(n: Int): Int = {
+    var ctr = 0
+    for (i <- 1 to n) {
+      for (j <- 1 to n) {
+        for (k <- 1 to n) {
+          for (m <- 1 to n) {
+            if (isSquare(f(i, j) + f(j, k) + f(k, m) + f(m, i))) {
+              ctr += 1
+            }
+          }
+        }
+      }
+    }
+    ctr
+  }
+
+}
+
+object Euler504T {
+
+  import TypeFramework.Bin._
+  import TypeFramework.Bool._
+  import TypeFramework.Funs._
+  import TypeFramework.TList._
+
+  trait F[A <: Bin, B <: Bin] { type Out <: Bin }
+  object F {
+    type Aux[A <: Bin, B <: Bin, R <: Bin] = F[A, B] { type Out = R }
+    implicit def c[A <: Bin, B <: Bin, Mul <: Bin, Gcd <: Bin](
+        implicit mul: BinMult.Aux[A, B, Mul],
+        gcd: BinGcd.Aux[A, B, Gcd],
+        dif: BinSub[Mul, Gcd]): F[A, B] { type Out = I[dif.Out] } = ???
+  }
+
+  implicitly[F[__3, __3] { type Out = __13 }]
+  implicitly[F[__3, __2] { type Out = __11 }]
+
+  trait Condition[I <: Bin, J <: Bin, K <: Bin, M <: Bin] { type Out <: Bin }
+  object Condition {
+    type Aux[I <: Bin, J <: Bin, K <: Bin, M <: Bin, R <: Bool] = Condition[I, J, K, M] { type Out = Bool }
+    implicit def c[I <: Bin, J <: Bin, K <: Bin, M <: Bin, FIJ <: Bin, FJK <: Bin, FKM <: Bin, FMI <: Bin, FIK <: Bin, FIM <: Bin, FII <: Bin, R <: Bool](
+        implicit fij: F.Aux[I, J, FIJ],
+        fjk: F.Aux[J, K, FJK],
+        fkm: F.Aux[K, M, FKM],
+        fmi: F.Aux[M, I, FMI],
+        fik: BinAdd.Aux[FIJ, FJK, FIK],
+        fim: BinAdd.Aux[FIK, FKM, FIM],
+        fii: BinAdd.Aux[FIM, FMI, FII],
+        out: BinIsSquare[FII]): Aux[I, J, K, M, out.Out] = ???
+  }
+
+  trait Fn3[I <: Bin, J <: Bin, K <: Bin] extends Func
+  object Fn3 {
+    implicit def ct[I <: Bin, J <: Bin, K <: Bin, M <: Bin](
+      implicit v: Condition.Aux[I, J, K, M, True]): Apply.Aux[Fn3[I, J, K], M, __1] = ???
+    implicit def cf[I <: Bin, J <: Bin, K <: Bin, M <: Bin](
+      implicit v: Condition.Aux[I, J, K, M, False]): Apply.Aux[Fn3[I, J, K], M, __0] = ???
+  }
+
+  implicitly[Apply.Aux[Fn3[__1, __1, __1], __1, __1]]
+
+  trait Fn2[N <: Bin, I <: Bin, J <: Bin] extends Func
+  object Fn2 {
+    implicit def c[N <: Bin, I <: Bin, J <: Bin, K <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
+       implicit x: BinRange.Aux[N, L1],
+       v: ListMap.Aux[Fn3[I, J, K], L1, L2],
+       y: ListSum.Aux[L2, R]
+    ): Apply.Aux[Fn2[N, I, J], K, R] = ???
+
+    implicitly[BinRange.Aux[__1, Cons[__1, Nil]]]
+    implicitly[ListMap.Aux[Fn3[__1, __1, __1], Cons[__1, Nil], Cons[__1, Nil]]]
+    implicitly[ListSum.Aux[Cons[__1, Nil], __1]]
+    /* this implicit value fails to be found, which is weird since all the
+       parameters needed for the corresponding definition are there, as shown
+       directly above. */
+    // implicitly[Apply.Aux[Fn2[__1, __1, __1], __1, __1]]
+  }
+
+  trait Fn1[N <: Bin, I <: Bin] extends Func
+  object Fn1 {
+    implicit def c[N <: Bin, I <: Bin, J <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
+       implicit x: BinRange.Aux[N, L1],
+       v: ListMap.Aux[Fn2[N, I, J], L1, L2],
+       y: ListSum.Aux[L2, R]
+    ): Apply.Aux[Fn1[N, I], J, R] = ???
+  }
+
+  trait Fn0[N <: Bin] extends Func
+  object Fn0 {
+    implicit def c[N <: Bin, I <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
+       implicit x: BinRange.Aux[N, L1],
+       v: ListMap.Aux[Fn1[N, I], L1, L2],
+       y: ListSum.Aux[L2, R]
+    ): Apply.Aux[Fn0[N], I, R] = ???
+  }
+
+  trait Ans[N <: Bin] { type Out <: Bin }
+  object Ans {
+    type Aux[N <: Bin, R <: Bin] = Ans[N] { type Out = R }
+    implicit def c[N <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
+        implicit x: BinRange.Aux[N, L1],
+        v: ListMap.Aux[Fn0[N], L1, L2],
+        y: ListSum.Aux[L2, R]
+    ): Aux[N, R] = ???
+  }
+
+  implicitly[Ans.Aux[__0, __0]]
+
+  /* no amount of `Lazy` managed to get rid of fake divergence detections. */
+  // implicitly[Ans.Aux[__1, __1]]
+  // implicitly[Ans.Aux[__2, __5]]
+  // implicitly[Ans.Aux[__3, __13]]
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler504.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler504.scala
@@ -66,8 +66,20 @@ object Euler504T {
 
   trait Condition[I <: Bin, J <: Bin, K <: Bin, M <: Bin] { type Out <: Bin }
   object Condition {
-    type Aux[I <: Bin, J <: Bin, K <: Bin, M <: Bin, R <: Bool] = Condition[I, J, K, M] { type Out = Bool }
-    implicit def c[I <: Bin, J <: Bin, K <: Bin, M <: Bin, FIJ <: Bin, FJK <: Bin, FKM <: Bin, FMI <: Bin, FIK <: Bin, FIM <: Bin, FII <: Bin, R <: Bool](
+    type Aux[I <: Bin, J <: Bin, K <: Bin, M <: Bin, R <: Bool] =
+      Condition[I, J, K, M] { type Out = Bool }
+    implicit def c[I <: Bin,
+                   J <: Bin,
+                   K <: Bin,
+                   M <: Bin,
+                   FIJ <: Bin,
+                   FJK <: Bin,
+                   FKM <: Bin,
+                   FMI <: Bin,
+                   FIK <: Bin,
+                   FIM <: Bin,
+                   FII <: Bin,
+                   R <: Bool](
         implicit fij: F.Aux[I, J, FIJ],
         fjk: F.Aux[J, K, FJK],
         fkm: F.Aux[K, M, FKM],
@@ -81,19 +93,27 @@ object Euler504T {
   trait Fn3[I <: Bin, J <: Bin, K <: Bin] extends Func
   object Fn3 {
     implicit def ct[I <: Bin, J <: Bin, K <: Bin, M <: Bin](
-      implicit v: Condition.Aux[I, J, K, M, True]): Apply.Aux[Fn3[I, J, K], M, __1] = ???
+        implicit v: Condition.Aux[I, J, K, M, True])
+      : Apply.Aux[Fn3[I, J, K], M, __1] = ???
     implicit def cf[I <: Bin, J <: Bin, K <: Bin, M <: Bin](
-      implicit v: Condition.Aux[I, J, K, M, False]): Apply.Aux[Fn3[I, J, K], M, __0] = ???
+        implicit v: Condition.Aux[I, J, K, M, False])
+      : Apply.Aux[Fn3[I, J, K], M, __0] = ???
   }
 
   implicitly[Apply.Aux[Fn3[__1, __1, __1], __1, __1]]
 
   trait Fn2[N <: Bin, I <: Bin, J <: Bin] extends Func
   object Fn2 {
-    implicit def c[N <: Bin, I <: Bin, J <: Bin, K <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
-       implicit x: BinRange.Aux[N, L1],
-       v: ListMap.Aux[Fn3[I, J, K], L1, L2],
-       y: ListSum.Aux[L2, R]
+    implicit def c[N <: Bin,
+                   I <: Bin,
+                   J <: Bin,
+                   K <: Bin,
+                   L1 <: TList,
+                   L2 <: TList,
+                   R <: Bin](
+        implicit x: BinRange.Aux[N, L1],
+        v: ListMap.Aux[Fn3[I, J, K], L1, L2],
+        y: ListSum.Aux[L2, R]
     ): Apply.Aux[Fn2[N, I, J], K, R] = ???
 
     implicitly[BinRange.Aux[__1, Cons[__1, Nil]]]
@@ -107,19 +127,24 @@ object Euler504T {
 
   trait Fn1[N <: Bin, I <: Bin] extends Func
   object Fn1 {
-    implicit def c[N <: Bin, I <: Bin, J <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
-       implicit x: BinRange.Aux[N, L1],
-       v: ListMap.Aux[Fn2[N, I, J], L1, L2],
-       y: ListSum.Aux[L2, R]
+    implicit def c[N <: Bin,
+                   I <: Bin,
+                   J <: Bin,
+                   L1 <: TList,
+                   L2 <: TList,
+                   R <: Bin](
+        implicit x: BinRange.Aux[N, L1],
+        v: ListMap.Aux[Fn2[N, I, J], L1, L2],
+        y: ListSum.Aux[L2, R]
     ): Apply.Aux[Fn1[N, I], J, R] = ???
   }
 
   trait Fn0[N <: Bin] extends Func
   object Fn0 {
     implicit def c[N <: Bin, I <: Bin, L1 <: TList, L2 <: TList, R <: Bin](
-       implicit x: BinRange.Aux[N, L1],
-       v: ListMap.Aux[Fn1[N, I], L1, L2],
-       y: ListSum.Aux[L2, R]
+        implicit x: BinRange.Aux[N, L1],
+        v: ListMap.Aux[Fn1[N, I], L1, L2],
+        y: ListSum.Aux[L2, R]
     ): Apply.Aux[Fn0[N], I, R] = ???
   }
 

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler601.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/Euler601.scala
@@ -1,0 +1,89 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+
+/*
+Let f(n) = lcm_{i=1}^n i.
+
+If n + k is divisible by k + 1, then n - 1 is also divisible by k + 1. So,
+streak(n) = k <=> (f(k) divides n-1, but f(k) doesn't).
+
+P(s, N), hence, is the number of such n, 1 < n < N, that (n-1) is divided by
+f(s) but not by f(s+1). So, it is the number of such i = n-1, 0 < i < N-1. Thus,
+we can count numbers in range [1; N-2] that are divided by f(s) but not by
+f(s-1).
+
+How many multiples of f(s) are there? floor((N-2)/f(s)). How many of of them are
+multiples of f(s+1)? floor((N-2)/lcm(s+1, f(s))).
+
+This gives us an efficient method of calculating P(s, N).
+ */
+
+object Euler601 {
+
+  def gcd(a: Long, b: Long): Long = if (b == 0L) a else gcd(b, a % b)
+
+  def lcm(a: Long, b: Long) = a * b / gcd(a, b)
+
+  def f(n: Long): Long = (1L /: (1L to n))((x, y) => lcm(x, y))
+
+  def p(s: Long, n: Long): Long = (n - 2) / f(s) - (n - 2) / f(s + 1)
+
+  def ans: Long = {
+    var ctr = 0L
+    var p4 = 1L
+    for (i <- 1 to 31) {
+      p4 *= 4L
+      ctr += p(i, p4)
+    }
+    ctr
+  }
+}
+
+object Euler601T {
+
+  import TypeFramework.Bin._
+
+  trait F[A <: Bin] { type Out <: Bin }
+  object F {
+    type Aux[A <: Bin, B <: Bin] = F[A] { type Out = B }
+    implicit def cE: Aux[E, __1] = ???
+    implicit def cO[A <: Bin, B <: Bin, C <: Bin](
+        implicit p: BinPred.Aux[A, C],
+        c: Aux[C, B],
+        d: BinLcm[A, B]): Aux[A, d.Out] = ???
+  }
+
+  implicitly[F.Aux[__1, __1]]
+  implicitly[F.Aux[__2, __2]]
+  implicitly[F.Aux[__3, __6]]
+  implicitly[F.Aux[__4, __12]]
+
+  trait P[S <: Bin, N <: Bin] { type Out <: Bin }
+  object P {
+    type Aux[S <: Bin, N <: Bin, R <: Bin] = P[S, N] { type Out = R }
+    implicit def c[S <: Bin,
+                   N <: Bin,
+                   FS <: Bin,
+                   NM2 <: Bin,
+                   NM2sFS <: Bin,
+                   Z <: Bin,
+                   SS <: Bin,
+                   FSS <: Bin,
+                   NM2sFSS <: Bin,
+                   Y <: Bin](
+        implicit fa: F.Aux[S, FS],
+        nm2: BinSub.Aux[N, __2, NM2],
+        nm2sfa: BinDiv.Aux[NM2, FS, NM2sFS, Z],
+        sf: BinSuc.Aux[S, SS],
+        fsf: F.Aux[SS, FSS],
+        nm2sfsa: BinDiv.Aux[NM2, FSS, NM2sFSS, Y],
+        c: BinSub[NM2sFS, NM2sFSS]
+    ): Aux[S, N, c.Out] = ???
+  }
+
+  implicitly[P.Aux[__1, __4, __1]]
+  implicitly[P.Aux[__2, __16, __5]]
+  implicitly[P.Aux[__3, __64, __5]]
+  implicitly[P.Aux[__4, __256, __17]]
+  implicitly[P.Aux[__5, __1024, __0]] // already takes too long a long time
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
@@ -1,0 +1,364 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+
+object TypeFramework {
+
+  // -------------------------------- Booleans --------------------------------
+
+  object Bool {
+
+    trait Bool
+    trait True extends Bool
+    trait False extends Bool
+
+  }
+
+  // --------------------------------- Pairs ----------------------------------
+
+  object Pair {
+
+    trait Pair[+A, +B]
+
+  }
+
+  // ----------------------------- Natural numbers ----------------------------
+
+  object Nat {
+
+    trait Nat
+    trait Z extends Nat
+    trait S[R <: Nat] extends Nat
+
+    type _0 = Z
+    type _1 = S[Z]
+    type _2 = S[_1]
+    type _3 = S[_2]
+    type _4 = S[_3]
+    type _5 = S[_4]
+    type _6 = S[_5]
+    type _7 = S[_6]
+    type _8 = S[_7]
+    type _9 = S[_8]
+
+    trait NatAdd[A <: Nat, B <: Nat] { type Out <: Nat }
+    object NatAdd {
+      type Aux[A <: Nat, B <: Nat, C <: Nat] = NatAdd[A, B] { type Out = C }
+      implicit def cZ[B <: Nat]: Aux[Z, B, B] = ???
+      implicit def cS[A <: Nat, B <: Nat](
+          implicit c: NatAdd[A, B]): Aux[S[A], B, S[c.Out]] = ???
+    }
+
+    implicitly[NatAdd.Aux[_3, _4, _7]]
+
+    trait NatSub[A <: Nat, B <: Nat] { type Out <: Nat }
+    object NatSub {
+      type Aux[A <: Nat, B <: Nat, C <: Nat] = NatSub[A, B] { type Out = C }
+      implicit def cB[A <: Nat]: Aux[A, Z, A] = ???
+      implicit def cS[A <: Nat, B <: Nat](
+          implicit c: NatSub[A, B]): Aux[S[A], S[B], c.Out] = ???
+    }
+
+    implicitly[NatSub.Aux[_7, _5, _2]]
+
+    trait NatMult[A <: Nat, B <: Nat] { type Out <: Nat }
+    object NatMult {
+      type Aux[A <: Nat, B <: Nat, C <: Nat] = NatMult[A, B] { type Out = C }
+      implicit def cZ[B <: Nat]: Aux[Z, B, Z] = ???
+      implicit def cS[A <: Nat, B <: Nat, R <: Nat](
+          implicit c: Aux[A, B, R],
+          p: NatAdd[R, B]): Aux[S[A], B, p.Out] = ???
+    }
+
+    implicitly[NatMult.Aux[_3, _2, _6]]
+
+    trait NatLt[A <: Nat, B <: Nat]
+    object NatLt {
+      implicit def cA[B <: Nat]: NatLt[Z, S[B]] = ???
+      implicit def cS[A <: Nat, B <: Nat](
+          implicit c: NatLt[A, B]): NatLt[S[A], S[B]] = ???
+    }
+
+    implicitly[NatLt[_0, _8]]
+    implicitly[NatLt[_0, _1]]
+    implicitly[NatLt[_7, _8]]
+
+    trait NatQuotRem[A <: Nat, B <: Nat] { type Out <: Pair.Pair[Nat, Nat] }
+    object NatQuotRem {
+      type Aux[A <: Nat, B <: Nat, Q <: Nat, R <: Nat] = NatQuotRem[A, B] {
+        type Out = Pair.Pair[Q, R]
+      }
+      implicit def cL[A <: Nat, B <: Nat](
+          implicit c: NatLt[A, B]): Aux[A, B, Z, A] = ???
+      implicit def cS[A <: Nat, B <: Nat, C <: Nat, D <: Nat, E <: Nat](
+          implicit c: NatLt[B, S[A]],
+          d: NatSub.Aux[A, B, C],
+          e: Aux[C, B, D, E]): Aux[A, B, S[D], E] = ???
+    }
+
+    implicitly[NatQuotRem.Aux[_7, _2, _3, _1]]
+
+  }
+
+  // ----------------------------- Binary numbers -----------------------------
+
+  object Bin {
+
+    trait Bin
+    trait E extends Bin
+    trait O[A <: Bin] extends Bin
+    trait I[A <: Bin] extends Bin
+
+    type __0 = E
+    type __1 = I[E]
+    type __2 = O[I[E]]
+    type __3 = I[I[E]]
+    type __4 = O[O[I[E]]]
+    type __5 = I[O[I[E]]]
+    type __6 = O[I[I[E]]]
+    type __7 = I[I[I[E]]]
+    type __8 = O[O[O[I[E]]]]
+    type __9 = I[O[O[I[E]]]]
+    type __10 = O[I[O[I[E]]]]
+    type __11 = I[I[O[I[E]]]]
+    type __12 = O[O[I[I[E]]]]
+    type __13 = I[O[I[I[E]]]]
+    type __14 = O[I[I[I[E]]]]
+    type __15 = I[I[I[I[E]]]]
+    type __16 = O[O[O[O[I[E]]]]]
+    type __17 = I[O[O[O[I[E]]]]]
+    type __18 = O[I[O[O[I[E]]]]]
+    type __64 = O[O[O[O[O[O[I[E]]]]]]]
+    type __256 = O[O[O[O[O[O[O[O[I[E]]]]]]]]]
+    type __1024 = O[O[O[O[O[O[O[O[O[O[I[E]]]]]]]]]]]
+
+    trait BinSuc[A <: Bin] { type Out <: Bin }
+    object BinSuc {
+      type Aux[A <: Bin, B <: Bin] = BinSuc[A] { type Out = B }
+      implicit def cE: Aux[E, I[E]] = ???
+      implicit def cO[A <: Bin]: Aux[O[A], I[A]] = ???
+      implicit def cI[A <: Bin](implicit c: BinSuc[A]): Aux[I[A], O[c.Out]] =
+        ???
+    }
+
+    implicitly[BinSuc.Aux[__0, __1]]
+    implicitly[BinSuc.Aux[__1, __2]]
+    implicitly[BinSuc.Aux[__6, __7]]
+    implicitly[BinSuc.Aux[__7, __8]]
+
+    trait BinAdd[A <: Bin, B <: Bin] { type Out <: Bin }
+    object BinAdd {
+      type Aux[A <: Bin, B <: Bin, C <: Bin] = BinAdd[A, B] { type Out = C }
+      implicit def cEB[B <: Bin]: Aux[E, B, B] = ???
+      implicit def cOE[A <: Bin]: Aux[O[A], E, O[A]] = ???
+      implicit def cIE[A <: Bin]: Aux[I[A], E, I[A]] = ???
+      implicit def cOO[A <: Bin, B <: Bin](
+          implicit c: BinAdd[A, B]): Aux[O[A], O[B], O[c.Out]] = ???
+      implicit def cOI[A <: Bin, B <: Bin](
+          implicit c: BinAdd[A, B]): Aux[O[A], I[B], I[c.Out]] = ???
+      implicit def cIO[A <: Bin, B <: Bin](
+          implicit c: BinAdd[A, B]): Aux[I[A], O[B], I[c.Out]] = ???
+      implicit def cII[A <: Bin, B <: Bin, C <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinSuc[C]): Aux[I[A], I[B], O[p.Out]] = ???
+    }
+
+    implicitly[BinAdd.Aux[__0, __0, __0]]
+    implicitly[BinAdd.Aux[__4, __2, __6]]
+    implicitly[BinAdd.Aux[__1, __1, __2]]
+
+    trait BinNorm[A <: Bin] { type Out <: Bin }
+    object BinNorm {
+      type Aux[A <: Bin, B <: Bin] = BinNorm[A] { type Out = B }
+      implicit def cE: Aux[E, E] = ???
+      implicit def cI[A <: Bin](implicit c: BinNorm[A]): Aux[I[A], I[c.Out]] =
+        ???
+      implicit def cOE[A <: Bin](implicit c: Aux[A, E]): Aux[O[A], E] = ???
+      implicit def cOO[A <: Bin, B <: Bin](
+          implicit c: Aux[A, O[B]]): Aux[O[A], O[O[B]]] = ???
+      implicit def cOI[A <: Bin, B <: Bin](
+          implicit c: Aux[A, I[B]]): Aux[O[A], O[I[B]]] = ???
+    }
+
+    implicitly[BinNorm.Aux[__0, __0]]
+    implicitly[BinNorm.Aux[__1, __1]]
+    implicitly[BinNorm.Aux[__2, __2]]
+    implicitly[BinNorm.Aux[__3, __3]]
+    implicitly[BinNorm.Aux[I[I[O[O[O[E]]]]], __3]]
+
+    trait BinPred[A <: Bin] { type Out <: Bin }
+    object BinPred {
+      type Aux[A <: Bin, B <: Bin] = BinPred[A] { type Out = B }
+      implicit def cI[A <: Bin](implicit c: BinNorm[O[A]]): Aux[I[A], c.Out] =
+        ???
+      implicit def cO[A <: Bin](implicit c: BinPred[A]): Aux[O[A], I[c.Out]] =
+        ???
+    }
+
+    implicitly[BinPred.Aux[__7, __6]]
+    implicitly[BinPred.Aux[__1, __0]]
+    implicitly[BinPred.Aux[__8, __7]]
+
+    trait BinSub[A <: Bin, B <: Bin] { type Out <: Bin }
+    object BinSub {
+      type Aux[A <: Bin, B <: Bin, C <: Bin] = BinSub[A, B] { type Out = C }
+      implicit def cAE[A <: Bin]: Aux[A, E, A] = ???
+      implicit def cOO[A <: Bin, B <: Bin, C <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinNorm[O[C]]): Aux[O[A], O[B], p.Out] = ???
+      implicit def cII[A <: Bin, B <: Bin, C <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinNorm[O[C]]): Aux[I[A], I[B], p.Out] = ???
+      implicit def cIO[A <: Bin, B <: Bin](
+          implicit c: BinSub[A, B]): Aux[I[A], O[B], I[c.Out]] = ???
+      implicit def cOI[A <: Bin, B <: Bin, C <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinPred[C]): Aux[O[A], I[B], I[p.Out]] = ???
+    }
+
+    implicitly[BinSub.Aux[__0, __0, __0]]
+    implicitly[BinSub.Aux[__1, __1, __0]]
+    implicitly[BinSub.Aux[__6, __4, __2]]
+    implicitly[BinSub.Aux[__6, __2, __4]]
+    implicitly[BinSub.Aux[__2, __1, __1]]
+
+    trait BinMult[A <: Bin, B <: Bin] { type Out <: Bin }
+    object BinMult {
+      type Aux[A <: Bin, B <: Bin, C <: Bin] = BinMult[A, B] { type Out = C }
+      implicit def cEB[B <: Bin]: Aux[E, B, E] = ???
+      implicit def cOB[A <: Bin, B <: Bin, C <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinNorm[O[C]]): Aux[O[A], B, p.Out] = ???
+      implicit def cIB[A <: Bin, B <: Bin, C <: Bin, D <: Bin](
+          implicit c: Aux[A, B, C],
+          p: BinAdd.Aux[B, O[C], D],
+          q: BinNorm[D]): Aux[I[A], B, q.Out] = ???
+    }
+
+    implicitly[BinMult.Aux[__0, __0, __0]]
+    implicitly[BinMult.Aux[__1, __1, __1]]
+    implicitly[BinMult.Aux[__2, __4, __8]]
+    implicitly[BinMult.Aux[__3, __3, __9]]
+    implicitly[BinMult.Aux[__3, __2, __6]]
+    implicitly[BinMult.Aux[__6, __3, __18]]
+
+    trait BinLe[A <: Bin, B <: Bin]
+    object BinLe {
+      implicit def cEB[B <: Bin]: BinLe[E, B] = ???
+      implicit def cOO[A <: Bin, B <: Bin](
+          implicit c: BinLe[A, B]): BinLe[O[A], O[B]] = ???
+      implicit def cII[A <: Bin, B <: Bin](
+          implicit c: BinLe[A, B]): BinLe[I[A], I[B]] = ???
+      implicit def cOI[A <: Bin, B <: Bin](
+          implicit c: BinLe[A, B]): BinLe[O[A], I[B]] = ???
+      implicit def cIO[A <: Bin, B <: Bin, C <: Bin](
+          implicit p: BinSuc.Aux[A, C],
+          c: BinLe[C, B]): BinLe[I[A], O[B]] = ???
+    }
+
+    implicitly[BinLe[__0, __0]]
+    implicitly[BinLe[__0, __1]]
+    implicitly[BinLe[__0, __6]]
+    implicitly[BinLe[__0, __8]]
+    implicitly[BinLe[__0, __8]]
+    implicitly[BinLe[__1, __1]]
+    implicitly[BinLe[__2, __2]]
+    implicitly[BinLe[__1, __2]]
+    implicitly[BinLe[__1, __6]]
+    implicitly[BinLe[__2, __5]]
+    implicitly[BinLe[__3, __4]]
+
+    trait BinLt[A <: Bin, B <: Bin]
+    object BinLt {
+      implicit def c[A <: Bin, B <: Bin, C <: Bin](
+          implicit p: BinSuc.Aux[A, C],
+          c: BinLe[C, B]): BinLt[A, B] = ???
+    }
+
+    implicitly[BinLt[__0, __1]]
+
+    trait BinDiv[A <: Bin, B <: Bin] { type Out <: Pair.Pair[Bin, Bin] }
+    object BinDiv {
+      type Aux[A <: Bin, B <: Bin, Q <: Bin, R <: Bin] = BinDiv[A, B] {
+        type Out = Pair.Pair[Q, R]
+      }
+      implicit def cL[A <: Bin, B <: Bin](
+          implicit c: BinLt[A, B]): Aux[A, B, E, A] = ???
+      implicit def cGOG[A <: Bin, B <: Bin, Q1 <: Bin, R1 <: Bin](
+          implicit c: BinLe[B, O[A]],
+          p: Aux[A, B, Q1, R1],
+          z: BinLe[B, O[R1]],
+          y: BinSub[O[R1], B]): Aux[O[A], B, I[Q1], y.Out] = ???
+      implicit def cGOL[A <: Bin, B <: Bin, Q1 <: Bin, R1 <: Bin](
+          implicit c: BinLe[B, O[A]],
+          p: Aux[A, B, Q1, R1],
+          z: BinLt[O[R1], B],
+          y: BinNorm[O[R1]],
+          x: BinNorm[O[Q1]]): Aux[O[A], B, x.Out, y.Out] = ???
+      implicit def cGIG[A <: Bin, B <: Bin, Q1 <: Bin, R1 <: Bin](
+          implicit c: BinLe[B, I[A]],
+          p: Aux[A, B, Q1, R1],
+          z: BinLe[B, I[R1]],
+          y: BinSub[I[R1], B]): Aux[I[A], B, I[Q1], y.Out] = ???
+      implicit def cGIL[A <: Bin, B <: Bin, Q1 <: Bin, R1 <: Bin](
+          implicit c: BinLe[B, I[A]],
+          p: Aux[A, B, Q1, R1],
+          z: BinLt[I[R1], B],
+          x: BinNorm[O[Q1]]): Aux[I[A], B, x.Out, I[R1]] = ???
+    }
+
+    implicitly[BinDiv.Aux[__1, __1, __1, __0]]
+    implicitly[BinDiv.Aux[__1, __2, __0, __1]]
+    implicitly[BinDiv.Aux[__2, __2, __1, __0]]
+    implicitly[BinDiv.Aux[__3, __2, __1, __1]]
+    implicitly[BinDiv.Aux[__4, __2, __2, __0]]
+    implicitly[BinDiv.Aux[__5, __2, __2, __1]]
+    implicitly[BinDiv.Aux[__6, __2, __3, __0]]
+    implicitly[BinDiv.Aux[__7, __2, __3, __1]]
+    implicitly[BinDiv.Aux[__8, __2, __4, __0]]
+    implicitly[BinDiv.Aux[__9, __2, __4, __1]]
+    implicitly[BinDiv.Aux[__1, __3, __0, __1]]
+    implicitly[BinDiv.Aux[__2, __3, __0, __2]]
+    implicitly[BinDiv.Aux[__3, __3, __1, __0]]
+    implicitly[BinDiv.Aux[__4, __3, __1, __1]]
+    implicitly[BinDiv.Aux[__5, __3, __1, __2]]
+    implicitly[BinDiv.Aux[__6, __3, __2, __0]]
+    implicitly[BinDiv.Aux[__7, __3, __2, __1]]
+    implicitly[BinDiv.Aux[__8, __3, __2, __2]]
+    implicitly[BinDiv.Aux[__9, __3, __3, __0]]
+
+    trait BinGcd[A <: Bin, B <: Bin] { type Out <: Bin }
+    object BinGcd {
+      type Aux[A <: Bin, B <: Bin, C <: Bin] = BinGcd[A, B] { type Out = C }
+      implicit def cE[A <: Bin]: Aux[A, E, A] = ???
+      implicit def cLO[A <: Bin, B <: Bin, Q <: Bin, R <: Bin](
+          implicit p: BinDiv.Aux[A, O[B], Q, R],
+          c: BinGcd[O[B], R]): Aux[A, O[B], c.Out] = ???
+      implicit def cLI[A <: Bin, B <: Bin, Q <: Bin, R <: Bin](
+          implicit p: BinDiv.Aux[A, I[B], Q, R],
+          c: BinGcd[I[B], R]): Aux[A, I[B], c.Out] = ???
+    }
+
+    implicitly[BinGcd.Aux[__2, __3, __1]]
+    implicitly[BinGcd.Aux[__6, __3, __3]]
+    implicitly[BinGcd.Aux[__6, __4, __2]]
+    implicitly[BinGcd.Aux[__6, __1, __1]]
+    implicitly[BinGcd.Aux[__6, __0, __6]]
+    implicitly[BinGcd.Aux[__0, __6, __6]]
+
+    trait BinLcm[A <: Bin, B <: Bin] { type Out <: Bin }
+    object BinLcm {
+      type Aux[A <: Bin, B <: Bin, C <: Bin] = BinLcm[A, B] { type Out = C }
+      implicit def c[A <: Bin, B <: Bin, C <: Bin, D <: Bin, F <: Bin](
+          implicit p: BinGcd.Aux[A, B, C],
+          c: BinMult.Aux[A, B, D],
+          d: BinDiv.Aux[D, C, F, E]): Aux[A, B, F] = ???
+    }
+
+    implicitly[BinLcm.Aux[__6, __3, __6]]
+    implicitly[BinLcm.Aux[__6, __1, __6]]
+    implicitly[BinLcm.Aux[__2, __3, __6]]
+    implicitly[BinLcm.Aux[__6, __0, __0]]
+    implicitly[BinLcm.Aux[__0, __6, __0]]
+
+  }
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
@@ -122,7 +122,9 @@ object TypeFramework {
     trait BiCurry[F <: BiFunc, A] extends Func { type Out }
 
     object BiCurry {
-      implicit def qa[F <: BiFunc, A, B](implicit q: BiApply[F, A, B]): Apply.Aux[BiCurry[F, A], B, q.Out] = ???
+      implicit def qa[F <: BiFunc, A, B](
+          implicit q: BiApply[F, A, B]): Apply.Aux[BiCurry[F, A], B, q.Out] =
+        ???
     }
 
     object BiFunc {
@@ -157,9 +159,13 @@ object TypeFramework {
 
     trait ListMap[F <: Func, A <: TList] { type Out <: TList }
     object ListMap {
-      type Aux[F <: Func, A <: TList, C <: TList] = ListMap[F, A] { type Out = C }
+      type Aux[F <: Func, A <: TList, C <: TList] = ListMap[F, A] {
+        type Out = C
+      }
       implicit def cn[F <: Func]: Aux[F, Nil, Nil] = ???
-      implicit def cc[F <: Func, A, B, T <: TList, R <: TList](implicit p: Apply.Aux[F, A, B], c: Aux[F, T, R]): Aux[F, Cons[A, T], Cons[B, R]] = ???
+      implicit def cc[F <: Func, A, B, T <: TList, R <: TList](
+          implicit p: Apply.Aux[F, A, B],
+          c: Aux[F, T, R]): Aux[F, Cons[A, T], Cons[B, R]] = ???
     }
 
   }
@@ -351,7 +357,8 @@ object TypeFramework {
 
     trait BinEq[A <: Bin, B <: Bin]
     object BinEq {
-      implicit def c[A <: Bin, B <: Bin](implicit p1: BinLe[A, B], p2: BinLe[B, A]): BinEq[A, B] = ???
+      implicit def c[A <: Bin, B <: Bin](implicit p1: BinLe[A, B],
+                                         p2: BinLe[B, A]): BinEq[A, B] = ???
     }
 
     implicitly[BinEq[__5, __5]]
@@ -459,7 +466,8 @@ object TypeFramework {
           c: BinRange[P]): Aux[A, Cons[A, c.Out]] = ???
     }
 
-    implicitly[BinRange.Aux[__4, Cons[__4, Cons[__3, Cons[__2, Cons[__1, Nil]]]]]]
+    implicitly[
+      BinRange.Aux[__4, Cons[__4, Cons[__3, Cons[__2, Cons[__1, Nil]]]]]]
 
     trait BinIsSquare[A <: Bin] { type Out <: Bool }
     object BinIsSquare {
@@ -468,31 +476,59 @@ object TypeFramework {
 
       trait IsSquareHelper[N <: Bin, L <: Bin, H <: Bin] { type Out <: Bool }
       object IsSquareHelper {
-        type Aux[N <: Bin, L <: Bin, H <: Bin, R <: Bool] = IsSquareHelper[N, L, H] { type Out = R }
+        type Aux[N <: Bin, L <: Bin, H <: Bin, R <: Bool] =
+          IsSquareHelper[N, L, H] { type Out = R }
         trait Mid[A <: Bin, B <: Bin] { type Out <: Bin }
         object Mid {
           type Aux[A <: Bin, B <: Bin, C <: Bin] = Mid[A, B] { type Out = C }
-          implicit def c[A <: Bin, B <: Bin, Sum <: Bin](implicit v: BinAdd.Aux[A, B, Sum], p: BinHalve[Sum]): Mid[A, B] { type Out = p.Out } = ???
+          implicit def c[A <: Bin, B <: Bin, Sum <: Bin](
+              implicit v: BinAdd.Aux[A, B, Sum],
+              p: BinHalve[Sum]): Mid[A, B] { type Out = p.Out } = ???
         }
 
         implicitly[Mid.Aux[__1, __4, __2]]
         implicitly[Mid.Aux[__1, __5, __3]]
         implicitly[Mid.Aux[__0, __8, __4]]
 
-        implicit def searchEnd[N <: Bin, L <: Bin, H <: Bin](implicit b: BinLt[H, L]): Aux[N, L, H, False] = ???
+        implicit def searchEnd[N <: Bin, L <: Bin, H <: Bin](
+            implicit b: BinLt[H, L]): Aux[N, L, H, False] = ???
         implicit def itIs[N <: Bin, L <: Bin, H <: Bin, M <: Bin, MS <: Bin](
-          implicit b: BinLe[L, H], p: Mid.Aux[L, H, M], ms: BinMult.Aux[M, M, MS], be: BinEq[N, MS]): Aux[N, L, H, True] = ???
-        implicit def seeLt[N <: Bin, L <: Bin, H <: Bin, M <: Bin, MS <: Bin, MP <: Bin, R <: Bool](
-          implicit b: BinLe[L, H], p: Mid.Aux[L, H, M], ms: BinMult.Aux[M, M, MS], be: BinLt[N, MS],
-          mp: BinPred.Aux[M, MP], r: Lazy[Aux[N, L, MP, R]]): Aux[N, L, H, R] = ???
-        implicit def seeGt[N <: Bin, L <: Bin, H <: Bin, M <: Bin, MS <: Bin, MN <: Bin, R <: Bool](
-          implicit b: BinLe[L, H], p: Mid.Aux[L, H, M], ms: BinMult.Aux[M, M, MS], be: BinLt[MS, N],
-          mn: BinSuc.Aux[M, MN], r: Lazy[Aux[N, MN, H, R]]): Aux[N, L, H, R] = ???
+            implicit b: BinLe[L, H],
+            p: Mid.Aux[L, H, M],
+            ms: BinMult.Aux[M, M, MS],
+            be: BinEq[N, MS]): Aux[N, L, H, True] = ???
+        implicit def seeLt[N <: Bin,
+                           L <: Bin,
+                           H <: Bin,
+                           M <: Bin,
+                           MS <: Bin,
+                           MP <: Bin,
+                           R <: Bool](
+            implicit b: BinLe[L, H],
+            p: Mid.Aux[L, H, M],
+            ms: BinMult.Aux[M, M, MS],
+            be: BinLt[N, MS],
+            mp: BinPred.Aux[M, MP],
+            r: Lazy[Aux[N, L, MP, R]]): Aux[N, L, H, R] = ???
+        implicit def seeGt[N <: Bin,
+                           L <: Bin,
+                           H <: Bin,
+                           M <: Bin,
+                           MS <: Bin,
+                           MN <: Bin,
+                           R <: Bool](
+            implicit b: BinLe[L, H],
+            p: Mid.Aux[L, H, M],
+            ms: BinMult.Aux[M, M, MS],
+            be: BinLt[MS, N],
+            mn: BinSuc.Aux[M, MN],
+            r: Lazy[Aux[N, MN, H, R]]): Aux[N, L, H, R] = ???
       }
 
       implicitly[IsSquareHelper.Aux[__8, __0, __3, False]]
 
-      implicit def c[A <: Bin](implicit c: IsSquareHelper[A, __0, A]): Aux[A, c.Out] = ???
+      implicit def c[A <: Bin](
+          implicit c: IsSquareHelper[A, __0, A]): Aux[A, c.Out] = ???
     }
 
     implicitly[BinIsSquare.Aux[__0, True]]
@@ -510,10 +546,13 @@ object TypeFramework {
     object ListSum {
       type Aux[L <: TList, R <: Bin] = ListSum[L] { type Out = R }
       implicit def cn: Aux[Nil, __0] = ???
-      implicit def cc[H <: Bin, T <: TList, P <: Bin](implicit c: Aux[T, P], v: BinAdd[H, P]): Aux[Cons[H, T], v.Out] = ???
+      implicit def cc[H <: Bin, T <: TList, P <: Bin](
+          implicit c: Aux[T, P],
+          v: BinAdd[H, P]): Aux[Cons[H, T], v.Out] = ???
     }
 
-    implicitly[ListSum.Aux[Cons[__4, Cons[__3, Cons[__2, Cons[__1, Nil]]]], __10]]
+    implicitly[
+      ListSum.Aux[Cons[__4, Cons[__3, Cons[__2, Cons[__1, Nil]]]], __10]]
 
   }
 

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevel.scala
@@ -126,9 +126,15 @@ object TypeFramework {
     type __16 = O[O[O[O[I[E]]]]]
     type __17 = I[O[O[O[I[E]]]]]
     type __18 = O[I[O[O[I[E]]]]]
+    type __28 = O[O[I[I[I[E]]]]]
+    type __40 = O[O[O[I[O[I[E]]]]]]
+    type __53 = I[O[I[O[I[I[E]]]]]]
     type __64 = O[O[O[O[O[O[I[E]]]]]]]
+    type __100 = O[O[I[O[O[I[I[E]]]]]]]
     type __256 = O[O[O[O[O[O[O[O[I[E]]]]]]]]]
+    type __804 = O[O[I[O[O[I[O[O[I[I[E]]]]]]]]]]
     type __1024 = O[O[O[O[O[O[O[O[O[O[I[E]]]]]]]]]]]
+    type __2361 = I[O[O[I[I[I[O[O[I[O[O[I[E]]]]]]]]]]]]
 
     trait BinSuc[A <: Bin] { type Out <: Bin }
     object BinSuc {

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelI.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelI.scala
@@ -1,0 +1,303 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+import scala.language.higherKinds
+
+object TypeLevelI {
+
+  object Maybe {
+
+    sealed trait Maybe[T] {
+      type or[O <: Maybe[T]] <: Maybe[T]
+      type map[X, P[_ <: T] <: X] <: Maybe[X]
+      type get[O <: T] <: T
+    }
+
+    class Nothing[T] extends Maybe[T] {
+      type or[O <: Maybe[T]] = O
+      type map[X, P[_ <: T] <: X] = Nothing[X]
+      type get[O <: T] = O
+    }
+
+    class Just[T, A <: T] extends Maybe[T] {
+      type or[_ <: Maybe[T]] = Just[T, A]
+      type map[X, P[_ <: T] <: X] = Just[X, P[A]]
+      type get[_ <: T] = A
+    }
+
+  }
+
+  object Bool {
+
+    sealed trait Bool {
+      type select[U, A <: U, B <: U] <: U
+      type and[O <: Bool] <: Bool
+      type or[O <: Bool] <: Bool
+      type not <: Bool
+    }
+
+    class T extends Bool {
+      type select[U, A <: U, B <: U] = A
+      type and[O <: Bool] = O
+      type or[_ <: Bool] = T
+      type not = F
+    }
+
+    class F extends Bool {
+      type select[U, A <: U, B <: U] = B
+      type and[_ <: Bool] = F
+      type or[O <: Bool] = O
+      type not = T
+    }
+
+  }
+
+  object Bin {
+
+    import Bool._
+
+    sealed trait Bin {
+      type isZero <: Bool
+      type suc <: Bin
+      type norm <: Bin
+      type pred <: Bin
+      type add[Y <: Bin] <: Bin
+      type mul[Y <: Bin] <: Bin
+      type sub[Y <: Bin] <: Bin
+      type le[Y <: Bin] <: Bool
+      type mod2 <: Bin
+      type halve <: Bin
+
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] <: U
+
+      protected type addO[Y <: Bin] <: Bin
+      protected type addI[Y <: Bin] <: Bin
+      protected type subFromO[Y <: Bin] <: Bin
+      protected type subFromI[Y <: Bin] <: Bin
+      protected type leO[Y <: Bin] <: Bool
+      protected type leI[Y <: Bin] <: Bool
+    }
+
+    class E extends Bin {
+      type isZero = T
+      type suc = I[E]
+      type norm = E
+      type pred = E
+      type add[Y <: Bin] = Y
+      type mul[Y <: Bin] = E
+      type sub[Y <: Bin] = E
+      type le[Y <: Bin] = T
+      type mod2 = E
+      type halve = E
+
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] = A
+
+      protected type addO[Y <: Bin] = O[Y]
+      protected type addI[Y <: Bin] = I[Y]
+      protected type subFromO[Y <: Bin] = O[Y]
+      protected type subFromI[Y <: Bin] = I[Y]
+      protected type leO[Y <: Bin] = T
+      protected type leI[Y <: Bin] = T
+    }
+
+    class O[B <: Bin] extends Bin {
+      type isZero = B#isZero
+      type suc = I[B]
+      type norm = B#isZero#select[Bin, E, O[B#norm]]
+      type pred = I[B#pred]
+      type add[Y <: Bin] = Y#addO[B]
+      type sub[Y <: Bin] = Y#subFromO[B]
+      type le[Y <: Bin] = Y#suc#leO[B]#not
+      type mul[Y <: Bin] = O[B#mul[Y]]#norm
+      type mod2 = E
+      type halve = B
+
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] = F[O[B], pred#natCata[U, F, A]]
+
+      protected type addO[Y <: Bin] = O[B#add[Y]]
+      protected type addI[Y <: Bin] = I[B#add[Y]]
+      protected type subFromO[Y <: Bin] = O[Y#sub[B]]#norm
+      protected type subFromI[Y <: Bin] = I[Y#sub[B]]
+      protected type leO[Y <: Bin] = B#le[Y]
+      protected type leI[Y <: Bin] = B#le[Y]
+    }
+
+    class I[B <: Bin] extends Bin {
+      type isZero = F
+      type suc = O[B#suc]
+      type norm = I[B#norm]
+      type pred = O[B]#norm
+      type add[Y <: Bin] = Y#addI[B]
+      type sub[Y <: Bin] = Y#subFromI[B]
+      type le[Y <: Bin] = Y#suc#leI[B]#not
+      type mul[Y <: Bin] = O[B#mul[Y]]#norm#add[Y]
+      type mod2 = I[E]
+      type halve = B
+
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] = F[I[B], pred#natCata[U, F, A]]
+
+      protected type addO[Y <: Bin] = I[B#add[Y]]
+      protected type addI[Y <: Bin] = O[B#add[Y]#suc]
+      protected type subFromO[Y <: Bin] = I[Y#pred#sub[B]]
+      protected type subFromI[Y <: Bin] = O[Y#sub[B]]#norm
+      protected type leO[Y <: Bin] = B#suc#le[Y]
+      protected type leI[Y <: Bin] = B#le[Y]
+    }
+
+    type _0 = E
+    type _1 = I[E]
+    type _2 = O[I[E]]
+    type _3 = I[I[E]]
+    type _4 = O[O[I[E]]]
+    type _5 = I[O[I[E]]]
+    type _6 = O[I[I[E]]]
+    type _7 = I[I[I[E]]]
+    type _8 = O[O[O[I[E]]]]
+    type _9 = I[O[O[I[E]]]]
+    type _10 = O[I[O[I[E]]]]
+    type _11 = I[I[O[I[E]]]]
+    type _12 = O[O[I[I[E]]]]
+    type _13 = I[O[I[I[E]]]]
+    type _14 = O[I[I[I[E]]]]
+    type _15 = I[I[I[I[E]]]]
+    type _16 = O[O[O[O[I[E]]]]]
+    type _17 = I[O[O[O[I[E]]]]]
+    type _18 = O[I[O[O[I[E]]]]]
+
+    import Maybe._
+
+    object Ops {
+      type find[U, F[_ <: Bin] <: Maybe[U], N <: Bin] = N#suc#natCata[Maybe[U], ({type Z[A <: Bin, B <: Maybe[U]] = F[N#suc#sub[A]]#or[B]})#Z, Nothing[U]]
+
+      type eq[A <: Bin, B <: Bin] = A#le[B]#and[B#le[A]]
+
+      type isSquare[N <: Bin] = N#isZero#or[N#halve#suc#natCata[Bool, ({type Z[X <: Bin, B <: Bool] = eq[N, X#mul[X]]#or[B]})#Z, F]]
+    }
+
+    implicitly[_3#add[_6] =:= _9]
+    implicitly[_2#add[_6] =:= _8]
+
+    implicitly[_0#sub[_0] =:= _0]
+    implicitly[_1#sub[_1] =:= _0]
+    implicitly[_6#sub[_4] =:= _2]
+    implicitly[_6#sub[_2] =:= _4]
+    implicitly[_2#sub[_1] =:= _1]
+
+    implicitly[_0#le[_0] =:= T]
+    implicitly[_0#le[_1] =:= T]
+    implicitly[_0#le[_2] =:= T]
+    implicitly[_0#le[_3] =:= T]
+    implicitly[_0#le[_4] =:= T]
+    implicitly[_0#le[_5] =:= T]
+    implicitly[_0#le[_6] =:= T]
+    implicitly[_0#le[_7] =:= T]
+    implicitly[_0#le[_8] =:= T]
+    implicitly[_0#le[_9] =:= T]
+    implicitly[_1#le[_0] =:= F]
+    implicitly[_1#le[_1] =:= T]
+    implicitly[_1#le[_2] =:= T]
+    implicitly[_1#le[_3] =:= T]
+    implicitly[_1#le[_4] =:= T]
+    implicitly[_1#le[_5] =:= T]
+    implicitly[_1#le[_6] =:= T]
+    implicitly[_1#le[_7] =:= T]
+    implicitly[_1#le[_8] =:= T]
+    implicitly[_1#le[_9] =:= T]
+    implicitly[_2#le[_0] =:= F]
+    implicitly[_2#le[_1] =:= F]
+    implicitly[_2#le[_2] =:= T]
+    implicitly[_2#le[_3] =:= T]
+    implicitly[_2#le[_4] =:= T]
+    implicitly[_2#le[_5] =:= T]
+    implicitly[_2#le[_6] =:= T]
+    implicitly[_2#le[_7] =:= T]
+    implicitly[_2#le[_8] =:= T]
+    implicitly[_2#le[_9] =:= T]
+    implicitly[_3#le[_0] =:= F]
+    implicitly[_3#le[_1] =:= F]
+    implicitly[_3#le[_2] =:= F]
+    implicitly[_3#le[_3] =:= T]
+    implicitly[_3#le[_4] =:= T]
+    implicitly[_3#le[_5] =:= T]
+    implicitly[_3#le[_6] =:= T]
+    implicitly[_3#le[_7] =:= T]
+    implicitly[_3#le[_8] =:= T]
+    implicitly[_3#le[_9] =:= T]
+    implicitly[_4#le[_0] =:= F]
+    implicitly[_4#le[_1] =:= F]
+    implicitly[_4#le[_2] =:= F]
+    implicitly[_4#le[_3] =:= F]
+    implicitly[_4#le[_4] =:= T]
+    implicitly[_4#le[_5] =:= T]
+    implicitly[_4#le[_6] =:= T]
+    implicitly[_4#le[_7] =:= T]
+    implicitly[_4#le[_8] =:= T]
+    implicitly[_4#le[_9] =:= T]
+    implicitly[_5#le[_0] =:= F]
+    implicitly[_5#le[_1] =:= F]
+    implicitly[_5#le[_2] =:= F]
+    implicitly[_5#le[_3] =:= F]
+    implicitly[_5#le[_4] =:= F]
+    implicitly[_5#le[_5] =:= T]
+    implicitly[_5#le[_6] =:= T]
+    implicitly[_5#le[_7] =:= T]
+    implicitly[_5#le[_8] =:= T]
+    implicitly[_5#le[_9] =:= T]
+
+    implicitly[_10#mul[_10]#le[_10#mul[_10]#suc] =:= T]
+
+    implicitly[_0#norm =:= _0]
+    implicitly[_1#norm =:= _1]
+    implicitly[_2#norm =:= _2]
+    implicitly[_3#norm =:= _3]
+    implicitly[I[I[O[O[O[E]]]]]#norm =:= _3]
+
+    implicitly[_1#pred =:= _0]
+    implicitly[_2#pred =:= _1]
+    implicitly[_3#pred =:= _2]
+    implicitly[_4#pred =:= _3]
+    implicitly[_5#pred =:= _4]
+    implicitly[_6#pred =:= _5]
+    implicitly[_7#pred =:= _6]
+    implicitly[_8#pred =:= _7]
+    implicitly[_9#pred =:= _8]
+    implicitly[_10#pred =:= _9]
+    implicitly[_11#pred =:= _10]
+
+    implicitly[_0#suc  =:= _1]
+    implicitly[_1#suc  =:= _2]
+    implicitly[_2#suc  =:= _3]
+    implicitly[_3#suc  =:= _4]
+    implicitly[_4#suc  =:= _5]
+    implicitly[_5#suc  =:= _6]
+    implicitly[_6#suc  =:= _7]
+    implicitly[_7#suc  =:= _8]
+    implicitly[_8#suc  =:= _9]
+    implicitly[_9#suc  =:= _10]
+    implicitly[_10#suc =:= _11]
+    implicitly[_11#suc =:= _12]
+
+    implicitly[_4#natCata[Bin, ({type Z[A <: Bin, B <: Bin] = A#add[B]})#Z, _0] =:= _10]
+
+    implicitly[_4#natCata[Bin, ({type Z[A <: Bin, B <: Bin] = A#add[B]})#Z, _0] =:= _10]
+
+    implicitly[Ops.find[Bin, ({type Z[N <: Bin] = Just[Bin, N]})#Z, _10] =:= Just[Bin, _0]]
+    implicitly[Ops.find[Bin, ({type Z[N <: Bin] = N#le[_5]#not#select[Maybe[Bin], Just[Bin, N], Nothing[Bin]]})#Z, _10] =:= Just[Bin, _6]]
+
+    implicitly[Ops.eq[_3, _3] =:= T]
+    implicitly[Ops.eq[_4, _4] =:= T]
+    implicitly[Ops.eq[_0, _0] =:= T]
+    implicitly[Ops.eq[_0, _1] =:= F]
+
+    implicitly[Ops.isSquare[_0] =:= T]
+    implicitly[Ops.isSquare[_1] =:= T]
+    implicitly[Ops.isSquare[_2] =:= F]
+    implicitly[Ops.isSquare[_3] =:= F]
+    implicitly[Ops.isSquare[_4] =:= T]
+    implicitly[Ops.isSquare[_5] =:= F]
+    implicitly[Ops.isSquare[_6] =:= F]
+    implicitly[Ops.isSquare[_7] =:= F]
+    implicitly[Ops.isSquare[_8] =:= F]
+    implicitly[Ops.isSquare[_9] =:= T]
+
+  }
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelI.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelI.scala
@@ -110,7 +110,8 @@ object TypeLevelI {
       type mod2 = E
       type halve = B
 
-      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] = F[O[B], pred#natCata[U, F, A]]
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] =
+        F[O[B], pred#natCata[U, F, A]]
 
       protected type addO[Y <: Bin] = O[B#add[Y]]
       protected type addI[Y <: Bin] = I[B#add[Y]]
@@ -132,7 +133,8 @@ object TypeLevelI {
       type mod2 = I[E]
       type halve = B
 
-      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] = F[I[B], pred#natCata[U, F, A]]
+      type natCata[U, F[_ <: Bin, _ <: U] <: U, A <: U] =
+        F[I[B], pred#natCata[U, F, A]]
 
       protected type addO[Y <: Bin] = I[B#add[Y]]
       protected type addI[Y <: Bin] = O[B#add[Y]#suc]
@@ -165,11 +167,22 @@ object TypeLevelI {
     import Maybe._
 
     object Ops {
-      type find[U, F[_ <: Bin] <: Maybe[U], N <: Bin] = N#suc#natCata[Maybe[U], ({type Z[A <: Bin, B <: Maybe[U]] = F[N#suc#sub[A]]#or[B]})#Z, Nothing[U]]
+      type find[U, F[_ <: Bin] <: Maybe[U], N <: Bin] =
+        N#suc#natCata[Maybe[U],
+                      ({
+                        type Z[A <: Bin, B <: Maybe[U]] = F[N#suc#sub[A]]#or[B]
+                      })#Z,
+                      Nothing[U]]
 
       type eq[A <: Bin, B <: Bin] = A#le[B]#and[B#le[A]]
 
-      type isSquare[N <: Bin] = N#isZero#or[N#halve#suc#natCata[Bool, ({type Z[X <: Bin, B <: Bool] = eq[N, X#mul[X]]#or[B]})#Z, F]]
+      type isSquare[N <: Bin] =
+        N#isZero#or[N#halve#suc#natCata[Bool,
+                                        ({
+                                          type Z[X <: Bin, B <: Bool] =
+                                            eq[N, X#mul[X]]#or[B]
+                                        })#Z,
+                                        F]]
     }
 
     implicitly[_3#add[_6] =:= _9]
@@ -262,25 +275,37 @@ object TypeLevelI {
     implicitly[_10#pred =:= _9]
     implicitly[_11#pred =:= _10]
 
-    implicitly[_0#suc  =:= _1]
-    implicitly[_1#suc  =:= _2]
-    implicitly[_2#suc  =:= _3]
-    implicitly[_3#suc  =:= _4]
-    implicitly[_4#suc  =:= _5]
-    implicitly[_5#suc  =:= _6]
-    implicitly[_6#suc  =:= _7]
-    implicitly[_7#suc  =:= _8]
-    implicitly[_8#suc  =:= _9]
-    implicitly[_9#suc  =:= _10]
+    implicitly[_0#suc =:= _1]
+    implicitly[_1#suc =:= _2]
+    implicitly[_2#suc =:= _3]
+    implicitly[_3#suc =:= _4]
+    implicitly[_4#suc =:= _5]
+    implicitly[_5#suc =:= _6]
+    implicitly[_6#suc =:= _7]
+    implicitly[_7#suc =:= _8]
+    implicitly[_8#suc =:= _9]
+    implicitly[_9#suc =:= _10]
     implicitly[_10#suc =:= _11]
     implicitly[_11#suc =:= _12]
 
-    implicitly[_4#natCata[Bin, ({type Z[A <: Bin, B <: Bin] = A#add[B]})#Z, _0] =:= _10]
+    implicitly[_4#natCata[Bin,
+                          ({ type Z[A <: Bin, B <: Bin] = A#add[B] })#Z,
+                          _0] =:= _10]
 
-    implicitly[_4#natCata[Bin, ({type Z[A <: Bin, B <: Bin] = A#add[B]})#Z, _0] =:= _10]
+    implicitly[_4#natCata[Bin,
+                          ({ type Z[A <: Bin, B <: Bin] = A#add[B] })#Z,
+                          _0] =:= _10]
 
-    implicitly[Ops.find[Bin, ({type Z[N <: Bin] = Just[Bin, N]})#Z, _10] =:= Just[Bin, _0]]
-    implicitly[Ops.find[Bin, ({type Z[N <: Bin] = N#le[_5]#not#select[Maybe[Bin], Just[Bin, N], Nothing[Bin]]})#Z, _10] =:= Just[Bin, _6]]
+    implicitly[
+      Ops.find[Bin, ({ type Z[N <: Bin] = Just[Bin, N] })#Z, _10] =:= Just[Bin,
+                                                                           _0]]
+    implicitly[
+      Ops.find[Bin,
+               ({
+                 type Z[N <: Bin] =
+                   N#le[_5]#not#select[Maybe[Bin], Just[Bin, N], Nothing[Bin]]
+               })#Z,
+               _10] =:= Just[Bin, _6]]
 
     implicitly[Ops.eq[_3, _3] =:= T]
     implicitly[Ops.eq[_4, _4] =:= T]
@@ -297,6 +322,71 @@ object TypeLevelI {
     implicitly[Ops.isSquare[_7] =:= F]
     implicitly[Ops.isSquare[_8] =:= F]
     implicitly[Ops.isSquare[_9] =:= T]
+
+  }
+
+  object TList {
+
+    import Maybe._
+    import Bool._
+
+    trait TList[A] {
+
+      type head <: Maybe[A]
+      type tail <: Maybe[TList[A]]
+
+      type map[B, F[_ <: A] <: B] <: TList[B]
+
+      type foldr[B, F[_ <: A, _ <: B] <: B, X <: B] <: B
+
+      type isNil <: Bool
+
+    }
+
+    class Nil[A] extends TList[A] {
+
+      type head = Nothing[A]
+      type tail = Nothing[TList[A]]
+
+      type map[B, F[_ <: A] <: B] = Nil[B]
+
+      type foldr[B, F[_ <: A, _ <: B] <: B, X <: B] = X
+
+      type isNil = T
+
+    }
+
+    class Cons[A, Hd <: A, Tl <: TList[A]] extends TList[A] {
+
+      type head = Just[A, Hd]
+      type tail = Just[TList[A], Tl]
+
+      type map[B, F[_ <: A] <: B] = Cons[B, F[Hd], Tl#map[B, F]]
+
+      type foldr[B, F[_ <: A, _ <: B] <: B, X <: B] = F[Hd, Tl#foldr[B, F, X]]
+
+      type isNil = F
+
+    }
+
+    import Bin._
+
+    object Ops {
+
+      type sum[L <: TList[Bin]] =
+        L#foldr[Bin, ({ type Z[A <: Bin, B <: Bin] = A#add[B] })#Z, _0]
+      type replicate[U, B <: Bin, A <: U] =
+        B#natCata[TList[U],
+                  ({ type Z[_ <: Bin, B <: TList[U]] = Cons[U, A, B] })#Z,
+                  Nil[U]]
+
+    }
+
+    implicitly[Ops.sum[Cons[Bin, _2, Cons[Bin, _1, Nil[Bin]]]] =:= _3]
+    implicitly[Ops.sum[Ops.replicate[Bin, _0, _2]] =:= _0]
+    implicitly[Ops.sum[Ops.replicate[Bin, _1, _2]] =:= _2]
+    implicitly[Ops.sum[Ops.replicate[Bin, _2, _2]] =:= _4]
+    implicitly[Ops.sum[Ops.replicate[Bin, _3, _2]] =:= _6]
 
   }
 

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelLam.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelLam.scala
@@ -1,0 +1,196 @@
+package ru.hse.spb.jvm.scala.dkhalansky.euler
+import scala.language.higherKinds
+
+object TypeLevelLam {
+
+  sealed trait Maybe[T] {
+    type or[O <: Maybe[T]] <: Maybe[T]
+    type map[X, P[_ <: T] <: X] <: Maybe[X]
+    type get[O <: T] <: T
+  }
+
+  class Nothing[T] extends Maybe[T] {
+    type or[O <: Maybe[T]] = O
+    type map[X, P[_ <: T] <: X] = Nothing[X]
+    type get[O <: T] = O
+  }
+
+  class Just[T, A <: T] extends Maybe[T] {
+    type or[_ <: Maybe[T]] = Just[T, A]
+    type map[X, P[_ <: T] <: X] = Just[X, P[A]]
+    type get[_ <: T] = A
+  }
+
+  sealed trait Bool {
+    type select[U, A <: U, B <: U] <: U
+    type and[O <: Bool] <: Bool
+    type or[O <: Bool] <: Bool
+    type not <: Bool
+  }
+
+  class T extends Bool {
+    type select[U, A <: U, B <: U] = A
+    type and[O <: Bool] = O
+    type or[_ <: Bool] = T
+    type not = F
+  }
+
+  class F extends Bool {
+    type select[U, A <: U, B <: U] = B
+    type and[_ <: Bool] = F
+    type or[O <: Bool] = O
+    type not = T
+  }
+
+  sealed trait Nat {
+    type equals[N <: Nat] <: Bool
+    type leq[N <: Nat] <: Bool
+    type isZero <: Bool
+    type pred <: Nat
+
+    type plus[N <: Nat] <: Nat
+    type mult[N <: Nat] <: Nat
+    type fold[U, F[_ <: U] <: U, A <: U] <: U
+  }
+
+  class Z extends Nat {
+    type equals[N <: Nat] = N#isZero
+    type leq[_ <: Nat] = T
+    type isZero = T
+    type pred = Z
+
+    type plus[N <: Nat] = N
+    type mult[N <: Nat] = Z
+    type fold[U, F[_ <: U] <: U, A <: U] = A
+  }
+
+  class S[Y <: Nat] extends Nat {
+    type equals[N <: Nat] = N#isZero#not#and[Y#equals[N#pred]]
+    type leq[N <: Nat] = N#isZero#not#and[Y#leq[N#pred]]
+    type isZero = F
+    type pred = Y
+
+    type plus[N <: Nat] = S[Y#plus[N]]
+    type mult[N <: Nat] = Y#mult[N]#plus[N]
+    type fold[U, F[_ <: U] <: U, A <: U] = Y#fold[U, F, F[A]]
+  }
+
+  type _0 = Z
+  type _1 = S[_0]
+  type _2 = S[_1]
+  type _3 = S[_2]
+  type _4 = S[_3]
+  type _5 = S[_4]
+  type _6 = S[_5]
+  type _7 = S[_6]
+  type _8 = S[_7]
+  type _9 = S[_8]
+  type _10 = S[_9]
+  type _100 = _10#mult[_10]
+
+  sealed trait Term {
+    type onVars[Rel[_ <: Nat, _ <: Nat] <: Bool,
+                Trans[_ <: Nat, _ <: Nat] <: Term,
+                Depth <: Nat] <: Term
+    type normalStep <: Maybe[Term]
+    type body <: Maybe[Term]
+  }
+
+  class L[X <: Term] extends Term {
+    type onVars[Rel[_ <: Nat, _ <: Nat] <: Bool,
+                Trans[_ <: Nat, _ <: Nat] <: Term,
+                Depth <: Nat] = L[X#onVars[Rel, Trans, S[Depth]]]
+    type normalStep = X#normalStep#map[Term, L]
+    type body = Just[Term, X]
+  }
+
+  class A[X <: Term, Y <: Term] extends Term {
+    type onVars[Rel[_ <: Nat, _ <: Nat] <: Bool,
+                Trans[_ <: Nat, _ <: Nat] <: Term,
+                Depth <: Nat] =
+      A[X#onVars[Rel, Trans, Depth], Y#onVars[Rel, Trans, Depth]]
+    type normalStep =
+      X#body#map[Term, ({ type Z[R <: Term] = TermOps.beta[R, Y] })#Z]#or[
+        X#normalStep#map[Term, ({ type Z[R <: Term] = A[R, Y] })#Z]]#or[
+        Y#normalStep#map[Term, ({ type Z[R <: Term] = A[X, R] })#Z]]
+    type body = Nothing[Term]
+  }
+
+  class V[I <: Nat] extends Term {
+    type onVars[Rel[_ <: Nat, _ <: Nat] <: Bool,
+                Trans[_ <: Nat, _ <: Nat] <: Term,
+                Depth <: Nat] =
+      Rel[Depth, I]#select[Term, Trans[Depth, I], V[I]]
+    type normalStep = Nothing[Term]
+    type body = Nothing[Term]
+  }
+
+  object TermOps {
+
+    type shift[Off <: Nat, T <: Term] =
+      T#onVars[({ type L[D <: Nat, I <: Nat] = D#leq[I] })#L,
+               ({ type L[D <: Nat, I <: Nat] = V[I#plus[Off]] })#L,
+               Z]
+
+    type shiftM1[T <: Term] =
+      T#onVars[({ type L[D <: Nat, I <: Nat] = D#leq[I] })#L,
+               ({ type L[D <: Nat, I <: Nat] = V[I#pred] })#L,
+               Z]
+
+    type subst[J <: Nat, S <: Term, T <: Term] =
+      T#onVars[({ type L[D <: Nat, I <: Nat] = D#plus[J]#equals[I] })#L,
+               ({ type L[D <: Nat, I <: Nat] = shift[D, S] })#L,
+               Z]
+
+    type beta[T <: Term, O <: Term] = shiftM1[subst[Z, shift[_1, O], T]]
+
+    type reduce[N <: Nat, T <: Term] =
+      N#fold[Term, ({ type Z[R <: Term] = R#normalStep#get[R] })#Z, T]
+
+  }
+
+  object Test {
+
+    implicitly[_3#mult[_2] =:= _6]
+    implicitly[_3#plus[_2] =:= _5]
+
+    // takes forever!
+    // implicitly[_5#mult[_10]#plus[_5#mult[_10]] =:= _100]
+
+    type term1 = L[L[L[A[A[V[_2], V[_3]], V[_1]]]]]
+    type term2 = L[A[A[V[_2], V[_0]], V[_1]]]
+    type tomega = L[A[V[_0], V[_0]]]
+    type tOmega = A[tomega, tomega]
+    type tI = L[V[_0]]
+
+    type tTrue = L[L[V[_1]]]
+    type tFalse = L[L[V[_0]]]
+    type tIf = tI
+    type tOr = L[L[A[A[V[_1], tTrue], V[_0]]]]
+    type tAnd = L[L[A[A[V[_1], V[_0]], tFalse]]]
+
+    implicitly[TermOps.shift[_4, term1] =:= L[L[L[A[A[V[_2], V[_7]], V[_1]]]]]]
+
+    implicitly[TermOps.shiftM1[TermOps.shift[_1, term1]] =:= term1]
+
+    implicitly[
+      TermOps.subst[_0, V[_0], term2] =:= L[A[A[V[_2], V[_0]], V[_1]]]]
+    implicitly[
+      TermOps.subst[_0, V[_1], term2] =:= L[A[A[V[_2], V[_0]], V[_2]]]]
+    implicitly[
+      TermOps.subst[_0, V[_2], term2] =:= L[A[A[V[_2], V[_0]], V[_3]]]]
+    implicitly[
+      TermOps.subst[_1, V[_0], term2] =:= L[A[A[V[_1], V[_0]], V[_1]]]]
+    implicitly[
+      TermOps.subst[_2, V[_0], term2] =:= L[A[A[V[_2], V[_0]], V[_1]]]]
+
+    implicitly[TermOps.beta[L[V[_0]], V[_8]] =:= L[V[_0]]]
+    implicitly[TermOps.beta[L[V[_1]], V[_8]] =:= L[V[_9]]]
+
+    implicitly[A[tI, tOmega]#normalStep =:= Just[Term, tOmega]]
+
+    implicitly[TermOps.reduce[_5, A[A[tAnd, tFalse], tTrue]] =:= tFalse]
+
+  }
+
+}

--- a/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelLam.scala
+++ b/src/main/scala/ru/hse/spb/jvm/scala/dkhalansky/euler/TypeLevelLam.scala
@@ -3,44 +3,9 @@ import scala.language.higherKinds
 
 object TypeLevelLam {
 
-  sealed trait Maybe[T] {
-    type or[O <: Maybe[T]] <: Maybe[T]
-    type map[X, P[_ <: T] <: X] <: Maybe[X]
-    type get[O <: T] <: T
-  }
-
-  class Nothing[T] extends Maybe[T] {
-    type or[O <: Maybe[T]] = O
-    type map[X, P[_ <: T] <: X] = Nothing[X]
-    type get[O <: T] = O
-  }
-
-  class Just[T, A <: T] extends Maybe[T] {
-    type or[_ <: Maybe[T]] = Just[T, A]
-    type map[X, P[_ <: T] <: X] = Just[X, P[A]]
-    type get[_ <: T] = A
-  }
-
-  sealed trait Bool {
-    type select[U, A <: U, B <: U] <: U
-    type and[O <: Bool] <: Bool
-    type or[O <: Bool] <: Bool
-    type not <: Bool
-  }
-
-  class T extends Bool {
-    type select[U, A <: U, B <: U] = A
-    type and[O <: Bool] = O
-    type or[_ <: Bool] = T
-    type not = F
-  }
-
-  class F extends Bool {
-    type select[U, A <: U, B <: U] = B
-    type and[_ <: Bool] = F
-    type or[O <: Bool] = O
-    type not = T
-  }
+  import TypeLevelI._
+  import Bool._
+  import Maybe._
 
   sealed trait Nat {
     type equals[N <: Nat] <: Bool
@@ -71,7 +36,7 @@ object TypeLevelLam {
     type pred = Y
 
     type plus[N <: Nat] = S[Y#plus[N]]
-    type mult[N <: Nat] = Y#mult[N]#plus[N]
+    type mult[N <: Nat] = N#plus[Y#mult[N]]
     type fold[U, F[_ <: U] <: U, A <: U] = Y#fold[U, F, F[A]]
   }
 


### PR DESCRIPTION
Здравствуйте. Тут четыре задачи, пятую докину вечером. Высылаю сейчас, потому что если вдруг посмотрите до вечера, хотелось бы уже знать, то ли это, что Вы хотели. UDP: доделал.

Здесь есть несколько файлов с фреймворками для вычисления на типах.

## TypeLevel

В этом файле описывается околологическое программирование на типах. Вычисление происходит посредством поиска implicit-значений заданного типа. Это подход, который использовался в проекте, который Вы показывали. Вычисления выглядят как отношения между значениями.

У этого подхода есть большое удобство: можно делать нечто вроде паттерн-матчинга. Но есть и проблема: оно очень плохо работает. В компилятор встроен детектор зацикливающегося поиска неявных значений, и этот детектор консервативный: он вылетает не только в том случае, когда видит явно, что для неявного значения требуется оно же, но и когда вычисление становится слишком ветвистым. Тогда компилятор сообщает, что произошло divergence.

Для борьбы с divergence существует обёртка `Lazy` в пакете `shapeless`. Если обернуть тип ленивого значения в `Lazy`, то когда компилятор хочет взорваться из-за слишком большой сложности вычислений и при этом цепочка была готова завершиться на этом `Lazy`, завершения не происходит. `Lazy` основан на макросах и когда-то работал на `macroparadise`.

Но и тут есть проблема: компилятор не сообщает при ошибке, где именно он нашёл расходимость. В итоге не всегда можно придумать, куда ставить стратегические `Lazy`.

## TypeLevelI

Фреймворк, основанный на синонимах типов. Он не позволяет делать pattern-matching, а также очень сильно ограничен тем, что в нём допускаются только вычисления, которые выполняются по структурно меньшему аргументу. При этом, когда пишешь с его использованием, нужно значительно меньше кода.

Этот фреймворк -- не панацея, потому что подстановка синонимов типов в компиляторе осуществляется не как-то по-хитрому, с очередью незаполненных дыр, а наивной рекурсией. Из-за этого достаточно большие вычисления приводят к переполнению стека при попытке компиляции.

## TypeLevelLam

Тут у меня было наивное представление, что, может, синонимы типов работают настолько быстрее программирования на логических отношениях, что, быть может, есть шанс нагородить поверх них высокоуровневый язык, на котором будет уже комфортно писать. Мне захотелось сделать не какую-нибудь стек-машину, а лямбда-исчисление, и я его сделал, проблема только в том, что на редукцию даже очень небольших термов требуется много времени и угроза переполнить стек. Решил оставить, чтобы показать, что это лямбда-исчисление можно весьма лаконично выразить. Функция `reduce`, которая доводит терм до нормальной формы, не тотальна по очевидным соображениям, а потому детектор циклов, естественно, её бы отмёл в её наивном виде, поэтому в неё нужно подавать количество шагов, за которое терм должен вычислиться. И проблема возникает даже на том этапе, когда мы просто хотим проитерироваться по достаточно большому для нетривиальных термов числу: одно это ест очень много памяти.